### PR TITLE
Update coveralls gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ group :static_code_analysis do
 end
 
 group :test do
-  gem 'coveralls', require: false
+  gem 'coveralls-ruby', require: false
   gem 'rspec'
   gem 'rspec_junit_formatter'
-  gem 'simplecov', '~> 0.13'
+  gem 'simplecov'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,22 +11,19 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    coveralls (0.7.2)
-      multi_json (~> 1.3)
-      rest-client (= 1.6.7)
-      simplecov (>= 0.7)
-      term-ansicolor (= 1.2.2)
-      thor (= 0.18.1)
+    coveralls-ruby (0.2.0)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
     docile (1.4.0)
     gem-release (2.2.2)
     hashdiff (1.0.1)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
-    multi_json (1.15.0)
+    json (2.6.1)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
@@ -36,8 +33,6 @@ GEM
     racc (1.6.0)
     rainbow (3.1.1)
     regexp_parser (2.2.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -68,16 +63,17 @@ GEM
     rubocop-rspec (2.8.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
-    simplecov (0.21.2)
+    simplecov (0.16.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
-    thor (0.18.1)
-    tins (0.13.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.2.1)
+    tins (1.31.0)
+      sync
     unicode-display_width (2.1.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -88,13 +84,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  coveralls
+  coveralls-ruby
   gem-release
   rspec
   rspec_junit_formatter
   rubocop
   rubocop-rspec
-  simplecov (~> 0.13)
+  simplecov
   url_canonicalize!
   webmock
 


### PR DESCRIPTION
It's now called `coveralls-ruby`

We can also remove the version dependency for
`simplecov` because this isn't the past.