### PR TITLE
v1.0.1: harden URL fetching, correct redirect handling, refresh tests and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
       contents: read
       id-token: write # for RubyGems Trusted Publishing (OIDC); no API key is stored
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -36,4 +36,4 @@ jobs:
           fi
 
       - name: Build and publish to RubyGems
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    uses: ./.github/workflows/verify-gem.yml
+
+  release:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # for RubyGems Trusted Publishing (OIDC); no API key is stored
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Check the tag matches the gem version
+        run: |
+          version="$(ruby -r./lib/url_canonicalize/version -e 'print URLCanonicalize::VERSION')"
+          if [ "v${version}" != "${GITHUB_REF_NAME}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match gem version v${version}" >&2
+            exit 1
+          fi
+
+      - name: Build and publish to RubyGems
+        uses: rubygems/release-gem@v1

--- a/.github/workflows/verify-gem.yml
+++ b/.github/workflows/verify-gem.yml
@@ -1,0 +1,46 @@
+name: Verify gem
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Build the gem
+        run: gem build url_canonicalize.gemspec -o url_canonicalize.gem
+
+      - name: Verify the gem contains exactly the whitelisted files
+        run: |
+          ruby -rrubygems/package -e '
+            files = Gem::Package.new("url_canonicalize.gem").contents.sort
+            expected = (Dir.glob("lib/**/*.rb") + %w[CHANGELOG.md LICENSE README.md SECURITY.md]).sort
+            unless files == expected
+              warn "Unexpected gem contents"
+              warn "  extra:   #{(files - expected).join(", ")}"
+              warn "  missing: #{(expected - files).join(", ")}"
+              abort
+            end
+            puts files
+          '
+
+      - name: Install the gem in a clean environment and require it
+        run: |
+          gem install url_canonicalize.gem --install-dir tmp/clean-gem-home --no-document
+          GEM_HOME=tmp/clean-gem-home GEM_PATH=tmp/clean-gem-home ruby -e '
+            require "url_canonicalize"
+            raise "String#canonicalize missing" unless "".respond_to?(:canonicalize)
+            puts "url_canonicalize #{URLCanonicalize::VERSION} installed and required cleanly"
+          '

--- a/.github/workflows/verify-gem.yml
+++ b/.github/workflows/verify-gem.yml
@@ -13,9 +13,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: '3.3'
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/docs/plans/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,10 @@ Naming/FileName:
   Description: 'Use snake_case for source file names.'
   Enabled: true
 
+Style/ModuleFunction:
+  Description: 'Match the SonarCloud rule S7918, which prefers extend self.'
+  EnforcedStyle: extend_self
+
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
   EnforcedStyle: nested

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,7 @@
+# Configuration for SonarCloud Automatic Analysis
+# https://docs.sonarsource.com/sonarcloud/advanced-setup/automatic-analysis/
+
+# Runtime code lives in lib; everything under spec is test code, so test-data
+# literals (IP addresses, repeated URLs) are not analyzed as production issues
+sonar.sources=lib
+sonar.tests=spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 **Implemented enhancements:**
 
+- Correct the redirect and canonical-link HTTP state machine: follow all
+  redirect responses consistently, bound redirect and canonical-link chains
+  with one visited-URL set and one hop budget, parse `Link` headers properly,
+  resolve relative references per RFC 3986, match HTML canonical links
+  case-insensitively against the document base URL, replace host-specific HEAD
+  behavior with a generic HEAD-to-GET fallback and preserve underlying error
+  causes [\#185](https://github.com/dominicsayers/url_canonicalize/issues/185)
 - Security: verify TLS, block unsafe destinations at every hop, pin DNS results,
   restrict ports, bound response bodies and enforce an overall deadline
   [\#184](https://github.com/dominicsayers/url_canonicalize/issues/184)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,132 +1,78 @@
 # Changelog
 
-## [Unreleased](https://github.com/dominicsayers/url_canonicalize/tree/HEAD)
+All notable changes to this project are documented in this file.
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.15...HEAD)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-**Implemented enhancements:**
+## [Unreleased]
 
-- Refresh the test and coverage strategy: replace `coveralls-ruby` with a
-  current SimpleCov release, enforce 100% line and branch coverage on CI,
-  test redirect and canonical-link behavior deterministically at the HTTP
-  boundary with WebMock, and isolate environment changes in every example
-  [\#189](https://github.com/dominicsayers/url_canonicalize/issues/189)
+### Security
+
+- Verify TLS certificates and hostnames, block unsafe destinations at every
+  hop, pin DNS results, restrict ports, bound response bodies and enforce an
+  overall deadline
+  ([#184](https://github.com/dominicsayers/url_canonicalize/issues/184))
+
+### Fixed
+
 - Correct the redirect and canonical-link HTTP state machine: follow all
   redirect responses consistently, bound redirect and canonical-link chains
   with one visited-URL set and one hop budget, parse `Link` headers properly,
   resolve relative references per RFC 3986, match HTML canonical links
   case-insensitively against the document base URL, replace host-specific HEAD
   behavior with a generic HEAD-to-GET fallback and preserve underlying error
-  causes [\#185](https://github.com/dominicsayers/url_canonicalize/issues/185)
-- Security: verify TLS, block unsafe destinations at every hop, pin DNS results,
-  restrict ports, bound response bodies and enforce an overall deadline
-  [\#184](https://github.com/dominicsayers/url_canonicalize/issues/184)
-- Feature: return a Nokogiri XML document if requested [\#5](https://github.com/dominicsayers/url_canonicalize/issues/5)
+  causes ([#185](https://github.com/dominicsayers/url_canonicalize/issues/185))
 
-**Merged pull requests:**
+### Changed
 
-- Version 0.2 [\#6](https://github.com/dominicsayers/url_canonicalize/pull/6) ([dominicsayers](https://github.com/dominicsayers))
+- Refresh the test and coverage strategy: replace `coveralls-ruby` with a
+  current SimpleCov release, enforce 100% line and branch coverage on CI,
+  test redirect and canonical-link behavior deterministically at the HTTP
+  boundary and isolate environment changes in every example
+  ([#189](https://github.com/dominicsayers/url_canonicalize/issues/189))
+- Refresh gem packaging and release automation: package a deterministic
+  whitelist of runtime files, verify the built gem in CI, add full RubyGems
+  metadata, publish through RubyGems Trusted Publishing from a tag-triggered
+  workflow, and document security reporting and release procedures
+  ([#190](https://github.com/dominicsayers/url_canonicalize/issues/190))
 
-## [v0.1.15](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.15) (2017-03-14)
+## [1.0.0] - 2024-01-27
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.14...v0.1.15)
+### Changed
 
-## [v0.1.14](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.14) (2017-03-13)
+- Require Ruby 3.1 or later
+- Adapt to the behavior of current `uri` gem releases
+- Update development dependencies and CI configuration
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.13...v0.1.14)
+## [0.2.1] - 2022-02-01
 
-## [v0.1.13](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.13) (2017-03-13)
+### Changed
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.12...v0.1.13)
+- Require a recent Nokogiri version
+- Update development dependencies, RuboCop configuration and CI configuration
 
-## [v0.1.12](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.12) (2017-03-13)
+## [0.2.0] - 2018-06-30
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.11...v0.1.12)
+### Added
 
-## [v0.1.11](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.11) (2017-03-13)
+- Return a Nokogiri XML document from a successful response when requested
+  ([#5](https://github.com/dominicsayers/url_canonicalize/issues/5))
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.10...v0.1.11)
+### Changed
 
-## [v0.1.10](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.10) (2017-03-13)
+- Require a secure Nokogiri version
 
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.9...v0.1.10)
+## 0.1.15 and earlier
 
-**Closed issues:**
+Releases from 0.0.1 (2016-10-20) to 0.1.15 (2017-03-14) predate this
+changelog format. Their history is available from the
+[v0.1.15 tag](https://github.com/dominicsayers/url_canonicalize/releases/tag/v0.1.15)
+and the
+[commit log](https://github.com/dominicsayers/url_canonicalize/commits/v0.1.15).
 
-- URLCanonicalize doesn't accept host names [\#4](https://github.com/dominicsayers/url_canonicalize/issues/4)
-
-## [v0.1.9](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.9) (2017-03-06)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.8...v0.1.9)
-
-## [v0.1.8](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.8) (2017-03-06)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.7...v0.1.8)
-
-**Closed issues:**
-
-- Use a later version of Ruby on CircleCI [\#3](https://github.com/dominicsayers/url_canonicalize/issues/3)
-
-## [v0.1.7](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.7) (2017-03-06)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.6...v0.1.7)
-
-**Closed issues:**
-
-- Insecure version of Nokogiri [\#2](https://github.com/dominicsayers/url_canonicalize/issues/2)
-
-## [v0.1.6](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.6) (2017-03-06)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.5...v0.1.6)
-
-## [v0.1.5](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.5) (2016-10-26)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.4...v0.1.5)
-
-## [v0.1.4](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.4) (2016-10-26)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.2...v0.1.4)
-
-## [v0.1.2](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.2) (2016-10-26)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.1...v0.1.2)
-
-## [v0.1.1](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.1) (2016-10-26)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.1.0...v0.1.1)
-
-## [v0.1.0](https://github.com/dominicsayers/url_canonicalize/tree/v0.1.0) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.7...v0.1.0)
-
-## [v0.0.7](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.7) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.6...v0.0.7)
-
-## [v0.0.6](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.6) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.5...v0.0.6)
-
-## [v0.0.5](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.5) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.4...v0.0.5)
-
-## [v0.0.4](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.4) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.3...v0.0.4)
-
-## [v0.0.3](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.3) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.2...v0.0.3)
-
-## [v0.0.2](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.2) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/v0.0.1...v0.0.2)
-
-## [v0.0.1](https://github.com/dominicsayers/url_canonicalize/tree/v0.0.1) (2016-10-20)
-
-[Full Changelog](https://github.com/dominicsayers/url_canonicalize/compare/fec855bec42813304f93c8ef87035f184b054344...v0.0.1)
-
-
-
-\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*
+[Unreleased]: https://github.com/dominicsayers/url_canonicalize/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/dominicsayers/url_canonicalize/compare/v0.2.1...v1.0.0
+[0.2.1]: https://github.com/dominicsayers/url_canonicalize/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/dominicsayers/url_canonicalize/compare/v0.1.15...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 **Implemented enhancements:**
 
+- Refresh the test and coverage strategy: replace `coveralls-ruby` with a
+  current SimpleCov release, enforce 100% line and branch coverage on CI,
+  test redirect and canonical-link behavior deterministically at the HTTP
+  boundary with WebMock, and isolate environment changes in every example
+  [\#189](https://github.com/dominicsayers/url_canonicalize/issues/189)
 - Correct the redirect and canonical-link HTTP state machine: follow all
   redirect responses consistently, bound redirect and canonical-link chains
   with one visited-URL set and one hop budget, parse `Link` headers properly,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 **Implemented enhancements:**
 
+- Security: verify TLS, block unsafe destinations at every hop, pin DNS results,
+  restrict ports, bound response bodies and enforce an overall deadline
+  [\#184](https://github.com/dominicsayers/url_canonicalize/issues/184)
 - Feature: return a Nokogiri XML document if requested [\#5](https://github.com/dominicsayers/url_canonicalize/issues/5)
 
 **Merged pull requests:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+## Development setup
+
+The Ruby version is managed with [mise](https://mise.jdx.dev/):
+
+```sh
+mise install
+bundle install
+```
+
+## Running the checks
+
+```sh
+bundle exec rspec    # tests; CI enforces 100% line and branch coverage
+bundle exec rubocop  # static code analysis
+```
+
+Please write tests first (the suite is TDD-driven), keep coverage at 100% and
+add a CHANGELOG entry under **Unreleased** for user-visible changes.
+
+## Releasing
+
+Releases are published to RubyGems by the tag-triggered
+[release workflow](.github/workflows/release.yml) using RubyGems
+[Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) — no API
+key is stored anywhere.
+
+1. Update `lib/url_canonicalize/version.rb`.
+2. Move the **Unreleased** notes in `CHANGELOG.md` under the new version
+   heading with today's date, and update the compare links.
+3. Commit, then tag the release commit and push it:
+
+   ```sh
+   git tag v1.2.3
+   git push origin main v1.2.3
+   ```
+
+The workflow verifies the gem's contents, installs it into a clean
+environment, checks the tag matches the gem version, and then publishes from
+the protected `release` environment.

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
-  gem 'simplecov'
+  gem 'simplecov', '~> 0.22.0'
   gem 'webmock'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :static_code_analysis do
 end
 
 group :test do
-  gem 'coveralls-ruby', require: false
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,12 @@ GEM
     json (2.21.1)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
+    mini_portile2 (2.8.9)
     mize (0.4.1)
       protocol (~> 2.0)
+    nokogiri (1.18.9)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.28.0)
@@ -78,10 +82,10 @@ GEM
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
-    ruby_parser (3.21.1)
+    ruby_parser (3.22.0)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
-    sexp_processor (4.17.2)
+    sexp_processor (4.17.5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -116,4 +120,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.5.15
+  4.0.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,25 +12,16 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     bigdecimal (3.3.1)
-    coveralls-ruby (0.2.0)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (1.0.1)
       bigdecimal
       rexml
     diff-lcs (1.5.1)
-    docile (1.4.1)
     gem-release (2.2.4)
     hashdiff (1.2.1)
     json (2.21.1)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     mini_portile2 (2.8.9)
-    mize (0.4.1)
-      protocol (~> 2.0)
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -41,8 +32,6 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
-    protocol (2.0.0)
-      ruby_parser (~> 3.0)
     public_suffix (6.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
@@ -82,23 +71,7 @@ GEM
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
-    ruby_parser (3.22.0)
-      racc (~> 1.5)
-      sexp_processor (~> 4.16)
-    sexp_processor (4.17.5)
-    simplecov (0.16.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    sync (0.5.0)
-    term-ansicolor (1.10.2)
-      mize
-      tins (~> 1.0)
-    thor (1.4.0)
-    tins (1.33.0)
-      bigdecimal
-      sync
+    simplecov (1.0.1)
     unicode-display_width (2.6.0)
     webmock (3.26.2)
       addressable (>= 2.8.0)
@@ -109,7 +82,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  coveralls-ruby
   gem-release
   rspec
   rspec_junit_formatter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,15 +16,12 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.5.1)
+    docile (1.4.1)
     gem-release (2.2.4)
     hashdiff (1.2.1)
     json (2.21.1)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
-    mini_portile2 (2.8.9)
-    nokogiri (1.18.9)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.28.0)
@@ -71,7 +68,12 @@ GEM
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
-    simplecov (1.0.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     unicode-display_width (2.6.0)
     webmock (3.26.2)
       addressable (>= 2.8.0)
@@ -87,9 +89,9 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rspec
-  simplecov
+  simplecov (~> 0.22.0)
   url_canonicalize!
   webmock
 
 BUNDLED WITH
-  4.0.16
+   2.5.15

--- a/README.md
+++ b/README.md
@@ -30,6 +30,83 @@ URI('http://www.twitter.com').canonicalize # => #<URI::HTTP:0x00000008767908 URL
 Addressable::URI.canonicalize('http://www.twitter.com') # => #<Addressable::URI:0x43c9 URI:https://twitter.com/>
 ```
 
+Options can be passed to the module API or any of the `canonicalize` extension
+methods:
+
+```ruby
+URLCanonicalize.fetch(
+  'https://example.com/article',
+  total_timeout: 10,
+  max_body_bytes: 512_000
+)
+
+'https://example.com/article'.canonicalize(total_timeout: 10)
+```
+
+## Security and limits
+
+URLCanonicalize treats every fetched URL as untrusted, including redirect and
+`rel="canonical"` destinations. Before connecting, it resolves the host,
+rejects the destination if any DNS answer is loopback, private, link-local,
+multicast, unspecified, reserved or otherwise not publicly routable, and pins
+the connection to the validated address. URLs containing user information are
+rejected. HTTPS always uses peer certificate and hostname verification; there
+is no option to disable TLS verification.
+
+IPv6 validation is fail-closed: only prefixes currently allocated in IANA's
+global-unicast registry are eligible, with special-purpose ranges excluded.
+
+Environment HTTP proxies are deliberately disabled because proxy-side DNS
+resolution would bypass destination validation. Ports `80` and `443` are the
+only ports allowed by default.
+
+The default resource limits are:
+
+- 30 seconds for the complete canonicalization operation, across every hop;
+- 8 seconds to open a connection, 15 seconds to read and 8 seconds to write;
+- 1 MiB for a buffered response body;
+- 10 followed redirects.
+
+Only successful GET responses with `text/html`, `application/xhtml+xml`,
+`application/xml` or `text/xml` media types are buffered. Media-type casing and
+parameters such as `charset` are accepted. Other response bodies are drained
+without being retained, and only HTML/XHTML responses are parsed for canonical
+link elements.
+
+All limits can be made stricter, and additional ports can be explicitly
+allowed:
+
+```ruby
+URLCanonicalize.fetch(
+  'https://example.com:8443/article',
+  allowed_ports: [443, 8443],
+  max_body_bytes: 256_000,
+  total_timeout: 5,
+  open_timeout: 2,
+  read_timeout: 3,
+  write_timeout: 2,
+  max_redirects: 5
+)
+```
+
+Private-network fetching is available only as an explicit escape hatch for
+trusted URLs:
+
+```ruby
+URLCanonicalize.fetch(
+  'http://intranet.example.test',
+  allow_private_networks: true
+)
+```
+
+Enabling `allow_private_networks` relaxes the SSRF protection. It still pins the
+resolved address and enforces the user-information and port policies.
+
+Policy violations raise `URLCanonicalize::Exception::Security`, oversized
+responses raise `URLCanonicalize::Exception::ResponseTooLarge`, and the overall
+deadline raises `URLCanonicalize::Exception::Timeout`. Other socket and TLS
+failures continue to surface as `URLCanonicalize::Exception::Failure`.
+
 ## More Information
 
 URLCanonical follows HTTP redirects and also looks for `rel="canonical"` hints

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The default resource limits are:
 - 30 seconds for the complete canonicalization operation, across every hop;
 - 8 seconds to open a connection, 15 seconds to read and 8 seconds to write;
 - 1 MiB for a buffered response body;
-- 10 followed redirects.
+- 10 followed hops, shared between redirects and followed canonical links.
 
 Only successful GET responses with `text/html`, `application/xhtml+xml`,
 `application/xml` or `text/xml` media types are buffered. Media-type casing and
@@ -106,6 +106,35 @@ Policy violations raise `URLCanonicalize::Exception::Security`, oversized
 responses raise `URLCanonicalize::Exception::ResponseTooLarge`, and the overall
 deadline raises `URLCanonicalize::Exception::Timeout`. Other socket and TLS
 failures continue to surface as `URLCanonicalize::Exception::Failure`.
+
+## How URLs are followed
+
+Every hop starts with a `HEAD` request. If the response carries no canonical
+hint in its headers, the request is retried as a `GET` so the HTML can be
+inspected. A `HEAD` request rejected with `403 Forbidden`,
+`405 Method Not Allowed` or `501 Not Implemented` is also retried once as a
+`GET`, because some servers refuse `HEAD` requests outright; an unsuccessful
+`GET` is not retried.
+
+All redirect responses (`301`, `302`, `303`, `307` and `308`) are followed
+through their `Location` header. A redirection without a usable `Location` is
+treated as a failure.
+
+Canonical URLs are discovered from `Link` response headers whose `rel` tokens
+include `canonical` (RFC 8288), and from `<link rel="canonical">` elements in
+the HTML `<head>`, matched case-insensitively. Header targets resolve against
+the request URL; HTML targets resolve against the document base URL, honouring
+any `<base href>` element. Absolute, protocol-relative, root-relative,
+path-relative and query-only references are all resolved per RFC 3986, and
+only `http` or `https` results are followed.
+
+Redirects and followed canonical links share a single visited-URL set and a
+single hop budget (`max_redirects`), so cycles and over-long chains always
+terminate. A cycle or exhausted budget returns the last successfully fetched
+response if there is one, and raises `URLCanonicalize::Exception::Redirect`
+otherwise. When a failure is caused by an underlying exception, that exception
+is preserved as the `cause` of the raised
+`URLCanonicalize::Exception::Failure`.
 
 ## More Information
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # URLCanonicalize
-[![Gem Version](https://badge.fury.io/rb/url_canonicalize.svg)](https://rubygems.org/gems/url_canonicalize)
+[![Gem Version](https://img.shields.io/gem/v/url_canonicalize.svg)](https://rubygems.org/gems/url_canonicalize)
 [![Gem downloads](https://img.shields.io/gem/dt/url_canonicalize.svg)](https://rubygems.org/gems/url_canonicalize)
-[![Build status](https://img.shields.io/circleci/project/dominicsayers/url_canonicalize/master.svg)](https://circleci.com/gh/dominicsayers/url_canonicalize)
-[![Maintainability](https://api.codeclimate.com/v1/badges/1f92f784d12741a942ec/maintainability)](https://codeclimate.com/github/dominicsayers/url_canonicalize/maintainability)
-[![Coverage Status](https://coveralls.io/repos/github/dominicsayers/url_canonicalize/badge.svg?branch=master)](https://coveralls.io/github/dominicsayers/url_canonicalize?branch=master)
-[![Dependency Status](https://dependencyci.com/github/dominicsayers/url_canonicalize/badge)](https://dependencyci.com/github/dominicsayers/url_canonicalize)
-[![Security](https://hakiri.io/github/dominicsayers/url_canonicalize/master.svg)](https://hakiri.io/github/dominicsayers/url_canonicalize/master)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/1b8d50209b8c41a2b8200e25a63d57b3)](https://www.codacy.com/app/dominicsayers/url_canonicalize)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/dominicsayers/url_canonicalize/tree/main.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/dominicsayers/url_canonicalize/tree/main)
+[![CodeQL](https://github.com/dominicsayers/url_canonicalize/actions/workflows/codeql-analysis.yml/badge.svg?branch=main)](https://github.com/dominicsayers/url_canonicalize/actions/workflows/codeql-analysis.yml)
 
 URLCanonicalize is a Ruby gem that finds the canonical version of a URL. It
 provides `canonicalize` methods for the String, URI::HTTP, URI::HTTPS and
 Addressable::URI classes.
+
+Ruby 3.1 or later is required.
 
 ## Installation
 
@@ -21,6 +19,9 @@ gem 'url_canonicalize'
 ```
 
 ## Usage
+
+Requiring the gem extends `String`, `URI::HTTP`, `URI::HTTPS` and
+`Addressable::URI` with a `canonicalize` method:
 
 ```ruby
 'http://www.twitter.com'.canonicalize # => 'https://twitter.com/'
@@ -42,6 +43,10 @@ URLCanonicalize.fetch(
 
 'https://example.com/article'.canonicalize(total_timeout: 10)
 ```
+
+If you prefer the module API without the core-class extensions, call
+`URLCanonicalize.canonicalize(url)` (returns the canonical URL string) or
+`URLCanonicalize.fetch(url)` (returns the full response object).
 
 ## Security and limits
 
@@ -135,6 +140,29 @@ response if there is one, and raises `URLCanonicalize::Exception::Redirect`
 otherwise. When a failure is caused by an underlying exception, that exception
 is preserved as the `cause` of the raised
 `URLCanonicalize::Exception::Failure`.
+
+## Errors
+
+All errors raised by the gem are subclasses of `URLCanonicalize::Exception`,
+so `rescue URLCanonicalize::Exception` catches everything below:
+
+| Exception | Raised when |
+| --------- | ----------- |
+| `Exception::URI` | the URL cannot be parsed, or is not `http`/`https` |
+| `Exception::Security` | a destination violates the SSRF, userinfo or port policy |
+| `Exception::Redirect` | a redirect or canonical-link chain loops or exceeds `max_redirects` |
+| `Exception::Timeout` | the operation exceeds `total_timeout` |
+| `Exception::ResponseTooLarge` | a response body exceeds `max_body_bytes` |
+| `Exception::Failure` | the request fails (network error, TLS failure or unsuccessful HTTP status) |
+
+When a failure wraps an underlying exception, the original is available as the
+raised error's `cause`.
+
+## Contributing and security
+
+Development and release instructions are in
+[CONTRIBUTING.md](CONTRIBUTING.md). Please report vulnerabilities privately as
+described in [SECURITY.md](SECURITY.md), not through public issues.
 
 ## More Information
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems. Instead, use GitHub's
+private vulnerability reporting: go to the repository's **Security** tab and
+choose **Report a vulnerability**, or visit
+<https://github.com/dominicsayers/url_canonicalize/security/advisories/new>.
+
+You should receive a response within a week. Please include a proof of concept
+or reproduction steps where possible.
+
+## Scope notes
+
+URLCanonicalize fetches caller-supplied URLs, so requests forged through
+redirects or canonical links (SSRF), TLS verification, resource exhaustion and
+destination policy bypasses are all in scope. The README's "Security and
+limits" section describes the protections the gem provides by default.

--- a/lib/monkey_patches/addressable/uri.rb
+++ b/lib/monkey_patches/addressable/uri.rb
@@ -3,9 +3,9 @@
 module Addressable
   # Patch for Addressable's URI class
   class URI
-    def self.canonicalize(uri)
+    def self.canonicalize(uri, **options)
       url = parse(uri).to_s # uri can be anything Addressable::URI can handle
-      canonical_url = URLCanonicalize.canonicalize(url)
+      canonical_url = URLCanonicalize.canonicalize(url, **options)
       parse(canonical_url)
     end
   end

--- a/lib/monkey_patches/string.rb
+++ b/lib/monkey_patches/string.rb
@@ -2,7 +2,7 @@
 
 # Patch for Ruby's String class
 class String
-  def canonicalize
-    URLCanonicalize.canonicalize(self)
+  def canonicalize(**options)
+    URLCanonicalize.canonicalize(self, **options)
   end
 end

--- a/lib/monkey_patches/uri.rb
+++ b/lib/monkey_patches/uri.rb
@@ -3,8 +3,8 @@
 module URI
   # URI having the HTTP protocol
   class HTTP
-    def canonicalize
-      new_url = URLCanonicalize.canonicalize(to_s)
+    def canonicalize(**options)
+      new_url = URLCanonicalize.canonicalize(to_s, **options)
       ::URI.parse(new_url)
     end
   end

--- a/lib/url_canonicalize.rb
+++ b/lib/url_canonicalize.rb
@@ -4,25 +4,30 @@ require 'uri'
 require 'addressable/uri'
 require 'net/http'
 require 'nokogiri'
+require 'timeout'
 
 autoload :OpenSSL, 'openssl'
 
 # Core methods
 module URLCanonicalize
+  autoload :BoundedBody, 'url_canonicalize/bounded_body'
+  autoload :Destination, 'url_canonicalize/destination'
   autoload :Exception, 'url_canonicalize/exception'
   autoload :HTTP, 'url_canonicalize/http'
+  autoload :MediaType, 'url_canonicalize/media_type'
+  autoload :Options, 'url_canonicalize/options'
   autoload :Request, 'url_canonicalize/request'
   autoload :Response, 'url_canonicalize/response'
   autoload :URI, 'url_canonicalize/uri'
   autoload :VERSION, 'url_canonicalize/version'
 
   class << self
-    def canonicalize(url)
-      fetch(url).url
+    def canonicalize(url, **options)
+      fetch(url, **options).url
     end
 
-    def fetch(url)
-      URLCanonicalize::HTTP.new(url).fetch
+    def fetch(url, **options)
+      URLCanonicalize::HTTP.new(url, **options).fetch
     end
   end
 end

--- a/lib/url_canonicalize.rb
+++ b/lib/url_canonicalize.rb
@@ -14,6 +14,7 @@ module URLCanonicalize
   autoload :Destination, 'url_canonicalize/destination'
   autoload :Exception, 'url_canonicalize/exception'
   autoload :HTTP, 'url_canonicalize/http'
+  autoload :LinkHeader, 'url_canonicalize/link_header'
   autoload :MediaType, 'url_canonicalize/media_type'
   autoload :Options, 'url_canonicalize/options'
   autoload :Request, 'url_canonicalize/request'
@@ -35,4 +36,3 @@ end
 require 'monkey_patches/uri'
 require 'monkey_patches/string'
 require 'monkey_patches/addressable/uri'
-require 'English' # Needed for $LAST_MATCH_INFO

--- a/lib/url_canonicalize/bounded_body.rb
+++ b/lib/url_canonicalize/bounded_body.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module URLCanonicalize
+  # String-compatible response buffer that enforces a maximum byte size
+  class BoundedBody < String
+    def initialize(max_bytes)
+      @max_bytes = max_bytes
+      super()
+    end
+
+    def <<(chunk)
+      raise URLCanonicalize::Exception::ResponseTooLarge, error_message if bytesize + chunk.bytesize > @max_bytes
+
+      super
+    end
+
+    private
+
+    def error_message
+      "Response body exceeds #{@max_bytes} bytes"
+    end
+  end
+end

--- a/lib/url_canonicalize/destination.rb
+++ b/lib/url_canonicalize/destination.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+require 'socket'
+
+module URLCanonicalize
+  # Resolves a URI to an address that is permitted by the fetch security policy
+  class Destination
+    FORBIDDEN_IPV4_RANGES = %w[
+      0.0.0.0/8
+      10.0.0.0/8
+      100.64.0.0/10
+      127.0.0.0/8
+      169.254.0.0/16
+      172.16.0.0/12
+      192.0.0.0/24
+      192.0.2.0/24
+      192.88.99.0/24
+      192.168.0.0/16
+      198.18.0.0/15
+      198.51.100.0/24
+      203.0.113.0/24
+      224.0.0.0/4
+      240.0.0.0/4
+    ].map { |range| IPAddr.new(range) }.freeze
+
+    # Fail closed: only prefixes in IANA's IPv6 Global Unicast Address Space registry are accepted.
+    ALLOCATED_IPV6_RANGES = %w[
+      2001:200::/23
+      2001:400::/23
+      2001:600::/23
+      2001:800::/22
+      2001:c00::/23
+      2001:e00::/23
+      2001:1200::/23
+      2001:1400::/22
+      2001:1800::/23
+      2001:1a00::/23
+      2001:1c00::/22
+      2001:2000::/19
+      2001:4000::/23
+      2001:4200::/23
+      2001:4400::/23
+      2001:4600::/23
+      2001:4800::/23
+      2001:4a00::/23
+      2001:4c00::/23
+      2001:5000::/20
+      2001:8000::/19
+      2001:a000::/20
+      2001:b000::/20
+      2003::/18
+      2400::/12
+      2410::/12
+      2600::/12
+      2610::/23
+      2620::/23
+      2630::/12
+      2800::/12
+      2a00::/12
+      2a10::/12
+      2c00::/12
+    ].map { |range| IPAddr.new(range) }.freeze
+
+    FORBIDDEN_IPV6_RANGES = %w[
+      2001::/23
+      2001:db8::/32
+      2002::/16
+    ].map { |range| IPAddr.new(range) }.freeze
+
+    class << self
+      def resolve(uri, options)
+        validate!(uri, options)
+        addresses = resolve_addresses(uri)
+        validate_addresses!(uri, addresses, options)
+        addresses.first
+      end
+
+      def validate!(uri, options)
+        raise URLCanonicalize::Exception::Security, 'URLs containing userinfo are not allowed' if uri.userinfo
+        return if options[:allowed_ports].include?(uri.port)
+
+        raise URLCanonicalize::Exception::Security, "Port #{uri.port} is not allowed"
+      end
+
+      private
+
+      def resolve_addresses(uri)
+        addresses = Addrinfo.getaddrinfo(uri.host, uri.port, nil, Socket::SOCK_STREAM)
+        addresses = addresses.map(&:ip_address).uniq
+        raise SocketError, "No addresses found for #{uri.host}" if addresses.empty?
+
+        addresses
+      end
+
+      def validate_addresses!(uri, addresses, options)
+        return if options[:allow_private_networks]
+
+        addresses.each do |address|
+          next if public_address?(address)
+
+          raise URLCanonicalize::Exception::Security,
+                "Address #{address} for #{uri.host} is not publicly routable"
+        end
+      end
+
+      def public_address?(value)
+        address = IPAddr.new(value)
+        address = address.native if address.ipv4_mapped?
+
+        if address.ipv4?
+          FORBIDDEN_IPV4_RANGES.none? { |range| range.include?(address) }
+        else
+          ALLOCATED_IPV6_RANGES.any? { |range| range.include?(address) } &&
+            FORBIDDEN_IPV6_RANGES.none? { |range| range.include?(address) }
+        end
+      end
+    end
+  end
+end

--- a/lib/url_canonicalize/exception.rb
+++ b/lib/url_canonicalize/exception.rb
@@ -7,6 +7,9 @@ module URLCanonicalize
     Failure = Class.new(self)
     Redirect = Class.new(self)
     Request = Class.new(self)
+    ResponseTooLarge = Class.new(self)
+    Security = Class.new(self)
+    Timeout = Class.new(self)
     URI = Class.new(self)
   end
 end

--- a/lib/url_canonicalize/http.rb
+++ b/lib/url_canonicalize/http.rb
@@ -30,7 +30,10 @@ module URLCanonicalize
     attr_reader :options
 
     def fetch_within_deadline
-      loop { break last_known_good if handle_response }
+      loop do
+        result = handle_response
+        break result if result
+      end
     end
 
     def initialize(raw_url, **options)
@@ -55,7 +58,8 @@ module URLCanonicalize
       request.with_uri(uri).fetch
     end
 
-    # Parse the response, and clear the response ready to follow the next redirect
+    # Parse the response, and clear the response ready to follow the next redirect.
+    # Returns the final response when canonicalization is complete, or nil to continue
     def handle_response
       result = parse_response
       @response = nil
@@ -69,7 +73,7 @@ module URLCanonicalize
       when URLCanonicalize::Response::Success
         handle_success
       when URLCanonicalize::Response::Redirect
-        redirect_loop_detected? || max_redirects_reached?
+        handle_redirect
       when URLCanonicalize::Response::CanonicalFound
         handle_canonical_found
       when URLCanonicalize::Response::Failure
@@ -79,54 +83,49 @@ module URLCanonicalize
       end
     end
 
-    def redirect_loop_detected?
-      if redirect_list.include?(response_url)
-        return true if last_known_good
+    def handle_redirect
+      reason = hop_refusal_reason
+      return follow_hop unless reason
 
-        raise URLCanonicalize::Exception::Redirect, 'Redirect loop detected'
-      end
-
-      redirect_list << response_url
-      increment_redirects
-      set_url_from_response
-      false
-    end
-
-    def max_redirects_reached?
-      return false unless @redirects > options[:max_redirects]
-      return true if last_known_good
-
-      raise URLCanonicalize::Exception::Redirect, "#{@redirects} redirects is too many"
-    end
-
-    def redirect_list
-      @redirect_list ||= []
-    end
-
-    def increment_redirects
-      @redirects = redirects + 1
-    end
-
-    def redirects
-      @redirects ||= 0
+      last_known_good || raise(URLCanonicalize::Exception::Redirect, reason)
     end
 
     def handle_canonical_found
       self.last_known_good = response.response
-      return true if response_url == url || redirect_list.include?(response_url)
+      return last_known_good if hop_refusal_reason
 
-      set_url_from_response
-      false
+      follow_hop
     end
 
-    def set_url_from_response
+    # Redirects and followed canonical links share one visited-URL set and one
+    # hop budget, so any cycle or over-long chain terminates deterministically
+    def hop_refusal_reason
+      return 'Redirect loop detected' if visited.include?(response_url)
+      return "#{hops + 1} redirects is too many" if hops >= options[:max_redirects]
+
+      nil
+    end
+
+    def follow_hop
+      visited << response_url
+      @hops = hops + 1
       self.url = response_url
+      nil
+    end
+
+    def visited
+      @visited ||= [url]
+    end
+
+    def hops
+      @hops ||= 0
     end
 
     def handle_failure
-      return true if last_known_good
+      return last_known_good if last_known_good
 
-      raise URLCanonicalize::Exception::Failure, "#{response.failure_class}: #{response.message}"
+      raise URLCanonicalize::Exception::Failure, "#{response.failure_class}: #{response.message}",
+            cause: response.error
     end
 
     def handle_unhandled_response
@@ -135,7 +134,6 @@ module URLCanonicalize
 
     def handle_success
       self.last_known_good = response
-      true
     end
 
     def url

--- a/lib/url_canonicalize/http.rb
+++ b/lib/url_canonicalize/http.rb
@@ -4,7 +4,11 @@ module URLCanonicalize
   # Persistent connection for possible repeated requests to the same host
   class HTTP
     def fetch
-      loop { break last_known_good if handle_response }
+      ::Timeout.timeout(
+        options[:total_timeout],
+        URLCanonicalize::Exception::Timeout,
+        "Canonicalization exceeded #{options[:total_timeout]} seconds"
+      ) { fetch_within_deadline }
     end
 
     def uri
@@ -17,15 +21,21 @@ module URLCanonicalize
     end
 
     def do_request(http_request)
-      http.request http_request
+      http.request(http_request) { |response| read_response_body(http_request, response) }
     end
 
     private
 
     attr_accessor :last_known_good
+    attr_reader :options
 
-    def initialize(raw_url)
+    def fetch_within_deadline
+      loop { break last_known_good if handle_response }
+    end
+
+    def initialize(raw_url, **options)
       @raw_url = raw_url
+      @options = URLCanonicalize::Options.new(**options)
     end
 
     # Fetch the response
@@ -133,46 +143,65 @@ module URLCanonicalize
     end
 
     def http
-      return @http if same_host_and_port # reuse connection
+      URLCanonicalize::Destination.validate!(uri, options)
+      return @http if same_origin? # reuse connection
 
       @previous = uri
       @http = new_http
     end
 
-    def same_host_and_port
-      uri.host == previous.host && uri.port == previous.port
+    def same_origin?
+      uri.scheme == previous.scheme && uri.host == previous.host && uri.port == previous.port
     end
 
     def previous
-      @previous ||= Struct.new(:host, :port).new
+      @previous ||= Struct.new(:scheme, :host, :port).new
     end
 
     def new_http
-      h = Net::HTTP.new uri.host, uri.port
+      h = Net::HTTP.new uri.host, uri.port, nil
 
-      h.open_timeout = options[:open_timeout]
-      h.read_timeout = options[:read_timeout]
-
+      h.ipaddr = URLCanonicalize::Destination.resolve(uri, options)
+      configure_timeouts(h)
       ssl!(h)
 
       h
     end
 
-    def ssl!(http)
-      if uri.scheme == 'https'
-        http.use_ssl = true # Can generate exception
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    def read_response_body(http_request, response)
+      if buffer_response_body?(http_request, response)
+        enforce_content_length!(response)
+        response.read_body(URLCanonicalize::BoundedBody.new(options[:max_body_bytes]))
       else
-        http.use_ssl = false
+        response.read_body { |_chunk| nil }
       end
     end
 
-    def options
-      @options ||= {
-        open_timeout: 8, # Twitter responds in >5s
-        read_timeout: 15,
-        max_redirects: 10
-      }
+    def buffer_response_body?(http_request, response)
+      http_request.method == 'GET' && response.is_a?(Net::HTTPSuccess) && URLCanonicalize::MediaType.buffered?(response)
+    end
+
+    def enforce_content_length!(response)
+      return unless response.content_length && response.content_length > options[:max_body_bytes]
+
+      raise URLCanonicalize::Exception::ResponseTooLarge,
+            "Response body exceeds #{options[:max_body_bytes]} bytes"
+    end
+
+    def configure_timeouts(http)
+      http.open_timeout = options[:open_timeout]
+      http.read_timeout = options[:read_timeout]
+      http.write_timeout = options[:write_timeout]
+    end
+
+    def ssl!(http)
+      if uri.scheme == 'https'
+        http.use_ssl = true # Can generate exception
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        http.verify_hostname = true
+      else
+        http.use_ssl = false
+      end
     end
   end
 end

--- a/lib/url_canonicalize/link_header.rb
+++ b/lib/url_canonicalize/link_header.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module URLCanonicalize
+  # Parses HTTP Link header fields (RFC 8288) far enough to find the target of
+  # the first link whose rel tokens include "canonical"
+  module LinkHeader
+    LINK_VALUE = /<([^>]*)>((?:\s*;\s*[\w!#$%&'*+.^`|~-]+\s*=\s*(?:"[^"]*"|[^",;]+))*)/
+    REL_PARAM = /;\s*rel\s*=\s*(?:"([^"]*)"|([^",;\s]+))/i
+    CANONICAL = 'canonical'
+
+    module_function
+
+    def canonical(response)
+      fields = response.get_fields('link')
+      return unless fields
+
+      fields.each do |field|
+        field.scan(LINK_VALUE) do |target, params|
+          return target if canonical?(params)
+        end
+      end
+
+      nil
+    end
+
+    def canonical?(params)
+      match = REL_PARAM.match(params)
+      return false unless match
+
+      rel = match[1] || match[2]
+      rel.split.any? { |token| token.casecmp?(CANONICAL) }
+    end
+  end
+end

--- a/lib/url_canonicalize/link_header.rb
+++ b/lib/url_canonicalize/link_header.rb
@@ -8,7 +8,7 @@ module URLCanonicalize
     REL_PARAM = /;\s*rel\s*=\s*(?:"([^"]*)"|([^",;\s]+))/i
     CANONICAL = 'canonical'
 
-    module_function
+    extend self
 
     def canonical(response)
       fields = response.get_fields('link')

--- a/lib/url_canonicalize/media_type.rb
+++ b/lib/url_canonicalize/media_type.rb
@@ -6,7 +6,7 @@ module URLCanonicalize
     HTML = %w[text/html application/xhtml+xml].freeze
     BUFFERED = (HTML + %w[application/xml text/xml]).freeze
 
-    module_function
+    extend self
 
     def buffered?(response)
       BUFFERED.include?(normalized(response))

--- a/lib/url_canonicalize/media_type.rb
+++ b/lib/url_canonicalize/media_type.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module URLCanonicalize
+  # Normalizes response media types for safe buffering and parsing decisions
+  module MediaType
+    HTML = %w[text/html application/xhtml+xml].freeze
+    BUFFERED = (HTML + %w[application/xml text/xml]).freeze
+
+    module_function
+
+    def buffered?(response)
+      BUFFERED.include?(normalized(response))
+    end
+
+    def html?(response)
+      HTML.include?(normalized(response))
+    end
+
+    def normalized(response)
+      response['content-type'].to_s.split(';', 2).first.to_s.strip.downcase
+    end
+  end
+end

--- a/lib/url_canonicalize/options.rb
+++ b/lib/url_canonicalize/options.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module URLCanonicalize
+  # Validated configuration for one canonicalization operation
+  class Options
+    DEFAULTS = {
+      allow_private_networks: false,
+      allowed_ports: [80, 443].freeze,
+      max_body_bytes: 1_048_576,
+      total_timeout: 30,
+      open_timeout: 8,
+      read_timeout: 15,
+      write_timeout: 8,
+      max_redirects: 10
+    }.freeze
+
+    POSITIVE_NUMERIC_OPTIONS = %i[total_timeout open_timeout read_timeout write_timeout].freeze
+    POSITIVE_INTEGER_OPTIONS = %i[max_body_bytes max_redirects].freeze
+
+    def initialize(**values)
+      validate_known_options!(values)
+
+      @values = DEFAULTS.merge(values)
+      validate!
+      @values[:allowed_ports] = @values[:allowed_ports].dup.freeze
+      @values.freeze
+      freeze
+    end
+
+    def [](key)
+      @values.fetch(key)
+    end
+
+    def to_h
+      @values.merge(allowed_ports: @values[:allowed_ports].dup)
+    end
+
+    private
+
+    def validate!
+      validate_private_networks!
+      validate_ports!
+      validate_positive_values!
+    end
+
+    def validate_known_options!(values)
+      unknown = values.keys - DEFAULTS.keys
+      raise ArgumentError, "Unknown options: #{unknown.join(', ')}" unless unknown.empty?
+    end
+
+    def validate_private_networks!
+      return if [true, false].include?(@values[:allow_private_networks])
+
+      raise ArgumentError, 'allow_private_networks must be true or false'
+    end
+
+    def validate_ports!
+      ports = @values[:allowed_ports]
+      valid = ports.is_a?(Array) && !ports.empty? && ports.all? do |port|
+        port.is_a?(Integer) && port.between?(1, 65_535)
+      end
+      return if valid
+
+      raise ArgumentError, 'allowed_ports must contain only valid TCP ports'
+    end
+
+    def validate_positive_values!
+      POSITIVE_NUMERIC_OPTIONS.each do |name|
+        value = @values[name]
+        raise ArgumentError, "#{name} must be positive" unless value.is_a?(Numeric) && value.positive?
+      end
+
+      POSITIVE_INTEGER_OPTIONS.each do |name|
+        value = @values[name]
+        raise ArgumentError, "#{name} must be positive" unless value.is_a?(Integer) && value.positive?
+      end
+    end
+  end
+end

--- a/lib/url_canonicalize/request.rb
+++ b/lib/url_canonicalize/request.rb
@@ -20,6 +20,13 @@ module URLCanonicalize
       Zlib::DataError
     ].freeze
 
+    # Unsuccessful responses to a HEAD request that trigger a retry with GET
+    HEAD_FALLBACK_RESPONSES = [
+      Net::HTTPForbidden,
+      Net::HTTPMethodNotAllowed,
+      Net::HTTPNotImplemented
+    ].freeze
+
     def fetch
       handle_response
     end
@@ -28,15 +35,13 @@ module URLCanonicalize
       @location ||= relative_to_absolute(response['location'])
     end
 
+    # Point this request at a new URI, discarding all state from the previous
+    # response so nothing leaks between hops
     def with_uri(uri)
       @uri = uri
 
       @url = nil
-      @host = nil
-      @request = nil
-      @response = nil
-      @location = nil
-      @html = nil
+      self.http_method = @default_http_method
 
       self
     end
@@ -48,6 +53,7 @@ module URLCanonicalize
     def initialize(http, http_method = :head)
       @http = http
       @http_method = http_method
+      @default_http_method = http_method
     end
 
     def response
@@ -72,36 +78,46 @@ module URLCanonicalize
       when Net::HTTPRedirection
         handle_redirection
       else
-        handle_failure
+        handle_unsuccessful
       end
     rescue *NETWORK_EXCEPTIONS => e
-      handle_failure(e.class, e.message)
+      handle_failure(e.class, e.message, e)
     end
 
     def handle_success
-      @canonical_url = $LAST_MATCH_INFO['url'] if (response['link'] || '') =~ /<(?<url>.+)>\s*;\s*rel="canonical"/i
+      @canonical_url = relative_to_absolute(URLCanonicalize::LinkHeader.canonical(response))
 
       return enhanced_response if canonical_url || http_method == :get
 
+      fallback_to_get
+    end
+
+    # Some servers reject HEAD requests outright, so any HEAD request rejected
+    # with one of these statuses is retried as a GET before giving up
+    def handle_unsuccessful
+      return fallback_to_get if http_method == :head && HEAD_FALLBACK_RESPONSES.any? { |klass| response.is_a?(klass) }
+
+      handle_failure
+    end
+
+    def fallback_to_get
       self.http_method = :get
       fetch
     end
 
+    # Follow any redirection that carries a usable Location header, whether the
+    # redirect is temporary or permanent. A redirection without one cannot be
+    # followed, so it is reported as a failure.
     def handle_redirection
-      case response
-      when Net::HTTPFound, Net::HTTPMovedTemporarily, Net::HTTPTemporaryRedirect # Temporary redirection
-        handle_success
-      else # Permanent redirection
-        if location
-          URLCanonicalize::Response::Redirect.new(location)
-        else
-          URLCanonicalize::Response::Failure.new(::URI::InvalidURIError, response['location'])
-        end
+      if location
+        URLCanonicalize::Response::Redirect.new(location)
+      else
+        URLCanonicalize::Response::Failure.new(::URI::InvalidURIError, response['location'])
       end
     end
 
-    def handle_failure(klass = response.class, message = response.message)
-      URLCanonicalize::Response::Failure.new(klass, message)
+    def handle_failure(klass = response.class, message = response.message, error = nil)
+      URLCanonicalize::Response::Failure.new(klass, message, error)
     end
 
     def enhanced_response
@@ -119,15 +135,22 @@ module URLCanonicalize
     end
 
     def canonical_url
-      @canonical_url ||= relative_to_absolute(canonical_url_raw)
+      @canonical_url ||= relative_to_absolute(canonical_url_element&.[]('href'), document_base_url)
     end
 
-    def canonical_url_raw
-      @canonical_url ||= canonical_url_element['href'] if canonical_url_element.is_a?(Nokogiri::XML::Element)
-    end
-
+    # The first HTML link element whose rel tokens include "canonical", however
+    # the tokens are cased, provided it has a usable href
     def canonical_url_element
-      @canonical_url_element ||= html&.xpath('//head/link[@rel="canonical"]')&.first
+      @canonical_url_element ||= html&.css('head link[rel]')&.find do |element|
+        element['rel'].split.any? { |token| token.casecmp?('canonical') } && !element['href'].to_s.strip.empty?
+      end
+    end
+
+    # HTML canonical links resolve against the document base URL, not the
+    # request URL, when the document declares one
+    def document_base_url
+      base_href = html&.at_css('head base[href]')&.[]('href')
+      relative_to_absolute(base_href) || url
     end
 
     def uri
@@ -138,10 +161,6 @@ module URLCanonicalize
       @url ||= uri.to_s
     end
 
-    def host
-      @host ||= uri.host
-    end
-
     def request_for_method
       r = base_request
       headers.each { |header_key, header_value| r[header_key] = header_value }
@@ -149,8 +168,6 @@ module URLCanonicalize
     end
 
     def base_request
-      check_http_method
-
       case http_method
       when :head
         Net::HTTP::Head.new uri
@@ -176,26 +193,19 @@ module URLCanonicalize
       @response = nil
       @location = nil
       @html = nil
+      @canonical_url = nil
+      @canonical_url_element = nil
     end
 
-    # Some sites treat HEAD requests as suspicious activity and block the
-    # requester after a few attempts. For these sites we'll use GET requests
-    # only
-    def check_http_method
-      @http_method = :get if /(linkedin|crunchbase).com/ =~ host
-    end
+    # Resolve absolute, protocol-relative, root-relative, path-relative and
+    # query-only references against the base URL per RFC 3986. Only http(s)
+    # results are usable
+    def relative_to_absolute(reference, base = url)
+      return unless reference
 
-    def relative_to_absolute(partial_url)
-      return unless partial_url
-
-      partial_uri = ::URI.parse(partial_url)
-
-      if partial_uri.host
-        partial_url # It's already absolute
-      else
-        ::URI.join(uri || url, partial_url).to_s
-      end
-    rescue ::URI::InvalidURIError
+      absolute = ::URI.join(base, reference.strip)
+      absolute.to_s if absolute.is_a?(::URI::HTTP)
+    rescue ::URI::InvalidURIError, ArgumentError, Encoding::CompatibilityError
       nil
     end
 

--- a/lib/url_canonicalize/request.rb
+++ b/lib/url_canonicalize/request.rb
@@ -214,7 +214,7 @@ module URLCanonicalize
 
       puts "#{http_method.upcase} #{url} #{response.code} #{response.message}"
 
-      return unless ENV['DEBUG'].casecmp('headers')
+      return unless ENV['DEBUG'].casecmp?('headers')
 
       response.each { |k, v| puts "  #{k}:\t#{v}" }
     end

--- a/lib/url_canonicalize/request.rb
+++ b/lib/url_canonicalize/request.rb
@@ -115,7 +115,7 @@ module URLCanonicalize
     end
 
     def html
-      @html ||= Nokogiri::HTML response.body
+      @html ||= Nokogiri::HTML(response.body) if URLCanonicalize::MediaType.html?(response)
     end
 
     def canonical_url
@@ -127,7 +127,7 @@ module URLCanonicalize
     end
 
     def canonical_url_element
-      @canonical_url_element ||= html.xpath('//head/link[@rel="canonical"]').first
+      @canonical_url_element ||= html&.xpath('//head/link[@rel="canonical"]')&.first
     end
 
     def uri

--- a/lib/url_canonicalize/request.rb
+++ b/lib/url_canonicalize/request.rb
@@ -122,7 +122,7 @@ module URLCanonicalize
 
     def enhanced_response
       if canonical_url
-        puts "  * canonical_url:\t#{canonical_url}" if ENV['DEBUG']
+        puts "  * canonical_url:\t#{canonical_url}" if ENV.fetch('DEBUG', nil)
         response_plus = URLCanonicalize::Response::Success.new(canonical_url, response, html)
         URLCanonicalize::Response::CanonicalFound.new(canonical_url, response_plus)
       else
@@ -210,11 +210,12 @@ module URLCanonicalize
     end
 
     def log_response
-      return unless ENV['DEBUG']
+      debug = ENV.fetch('DEBUG', nil)
+      return unless debug
 
       puts "#{http_method.upcase} #{url} #{response.code} #{response.message}"
 
-      return unless ENV['DEBUG'].casecmp?('headers')
+      return unless debug.casecmp?('headers')
 
       response.each { |k, v| puts "  #{k}:\t#{v}" }
     end

--- a/lib/url_canonicalize/response.rb
+++ b/lib/url_canonicalize/response.rb
@@ -13,7 +13,8 @@ module URLCanonicalize
       end
     end
 
-    Redirect = Class.new(Generic)
+    # A redirect to another URL
+    class Redirect < Generic; end
 
     # Add HTML to a successful response
     class Success < Generic
@@ -44,15 +45,17 @@ module URLCanonicalize
       end
     end
 
-    # It barfed
+    # It barfed. When the failure came from a rescued exception, `error` holds
+    # the original exception so callers can see the real cause
     class Failure
-      attr_reader :failure_class, :message
+      attr_reader :failure_class, :message, :error
 
       private
 
-      def initialize(failure_class, message)
+      def initialize(failure_class, message, error = nil)
         @failure_class = failure_class
         @message = message
+        @error = error
       end
     end
   end

--- a/lib/url_canonicalize/uri.rb
+++ b/lib/url_canonicalize/uri.rb
@@ -9,19 +9,18 @@ module URLCanonicalize
 
       def parse(url)
         uri = ::URI.parse decorate(url)
-        uri if valid? uri
+        validate! uri
+        uri
       rescue ::URI::InvalidURIError => e
         raise URLCanonicalize::Exception::URI, "#{e.class}: #{e.message}" # the original error becomes the cause
       end
 
       private
 
-      def valid?(uri)
+      def validate!(uri)
         raise URLCanonicalize::Exception::URI, "#{uri} must be http or https" unless VALID_CLASSES.include?(uri.class)
         raise URLCanonicalize::Exception::URI, "Missing host name in #{uri}" unless uri.host
         raise URLCanonicalize::Exception::URI, "Empty host name in #{uri}" if uri.host.empty?
-
-        true
       end
 
       def decorate(url)

--- a/lib/url_canonicalize/uri.rb
+++ b/lib/url_canonicalize/uri.rb
@@ -11,9 +11,7 @@ module URLCanonicalize
         uri = ::URI.parse decorate(url)
         uri if valid? uri
       rescue ::URI::InvalidURIError => e
-        new_exception = URLCanonicalize::Exception::URI.new("#{e.class}: #{e.message}")
-        new_exception.set_backtrace e.backtrace
-        raise new_exception
+        raise URLCanonicalize::Exception::URI, "#{e.class}: #{e.message}" # the original error becomes the cause
       end
 
       private

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+ruby = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-ruby = "latest"
+ruby = "3.1.7"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=dominicsayers_url_canonicalize
+sonar.organization=dominicsayers
+
+# Runtime code and CI configuration are analyzed as sources; the RSpec suite
+# is test code, so test-data literals (URLs, IP addresses) are not treated as
+# production duplication or hardcoded-IP findings
+sonar.sources=lib,.github/workflows
+sonar.tests=spec
+
+# The destination validator is an SSRF blocklist: enumerating the forbidden
+# address ranges as literals is its purpose (see lib/url_canonicalize/destination.rb)
+sonar.issue.ignore.multicriteria=ip1
+sonar.issue.ignore.multicriteria.ip1.ruleKey=ruby:S1313
+sonar.issue.ignore.multicriteria.ip1.resourceKey=lib/url_canonicalize/destination.rb

--- a/spec/monkey_patches/addressable/uri_spec.rb
+++ b/spec/monkey_patches/addressable/uri_spec.rb
@@ -14,4 +14,11 @@ describe Addressable::URI do
   it 'is the expected class' do
     expect(described_class.canonicalize(url)).to be_a(described_class)
   end
+
+  it 'forwards security options' do
+    allow(URLCanonicalize).to receive(:canonicalize).and_call_original
+
+    expect { described_class.canonicalize(url, unknown: true) }
+      .to raise_error(ArgumentError, 'Unknown options: unknown')
+  end
 end

--- a/spec/monkey_patches/string_spec.rb
+++ b/spec/monkey_patches/string_spec.rb
@@ -14,4 +14,11 @@ describe String do
   it 'is the expected class' do
     expect(url.canonicalize).to be_a(described_class)
   end
+
+  it 'forwards security options' do
+    allow(URLCanonicalize).to receive(:canonicalize).and_call_original
+
+    expect { url.canonicalize(unknown: true) }
+      .to raise_error(ArgumentError, 'Unknown options: unknown')
+  end
 end

--- a/spec/monkey_patches/uri_spec.rb
+++ b/spec/monkey_patches/uri_spec.rb
@@ -16,4 +16,11 @@ describe URI do
   it 'is the expected class' do
     expect(described_class.parse(url).canonicalize).to be_a(URI::HTTP)
   end
+
+  it 'forwards security options' do
+    allow(URLCanonicalize).to receive(:canonicalize).and_call_original
+
+    expect { described_class.parse(url).canonicalize(unknown: true) }
+      .to raise_error(ArgumentError, 'Unknown options: unknown')
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,15 +3,15 @@
 # SimpleCov
 unless ENV['NO_SIMPLECOV']
   require 'simplecov'
-  require 'coveralls'
 
-  if ENV['CIRCLE_ARTIFACTS']
-    dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')
-    SimpleCov.coverage_dir(dir)
+  SimpleCov.start do
+    add_filter '/spec/'
+    enable_coverage :branch
+
+    # Enforced only on full CI runs so partial local runs (a single spec file)
+    # do not fail on coverage they never attempted
+    minimum_coverage line: 100, branch: 100 if ENV['CI']
   end
-
-  SimpleCov.start { add_filter '/spec/' }
-  Coveralls.wear! if ENV['COVERALLS_REPO_TOKEN'] && Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.1')
 end
 
 # Webmock
@@ -21,7 +21,21 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # Specs
 require 'url_canonicalize'
 
+# Set an environment variable for the duration of a block, restoring the
+# original value afterwards so no example leaks environment state
+module EnvHelper
+  def with_env(key, value)
+    original = ENV.fetch(key, nil)
+    ENV[key] = value
+    yield
+  ensure
+    original.nil? ? ENV.delete(key) : ENV[key] = original
+  end
+end
+
 RSpec.configure do |config|
+  config.include EnvHelper
   config.run_all_when_everything_filtered = true
-  config.order = 'random'
+  config.order = :random
+  Kernel.srand config.seed
 end

--- a/spec/url_canonicalize/bounded_body_spec.rb
+++ b/spec/url_canonicalize/bounded_body_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe URLCanonicalize::BoundedBody do
+  it 'accepts chunks up to the byte limit' do
+    body = described_class.new(5)
+
+    body << '12' << '345'
+
+    expect(body).to eq('12345')
+  end
+
+  it 'applies the limit to bytes rather than characters' do
+    body = described_class.new(4)
+
+    body << '££'
+
+    expect { body << '£' }.to raise_error(URLCanonicalize::Exception::ResponseTooLarge)
+  end
+
+  it 'rejects a chunk before it would exceed the limit' do
+    body = described_class.new(5)
+    body << '1234'
+
+    expect { body << '56' }.to raise_error(
+      URLCanonicalize::Exception::ResponseTooLarge,
+      'Response body exceeds 5 bytes'
+    )
+    expect(body).to eq('1234')
+  end
+end

--- a/spec/url_canonicalize/destination_spec.rb
+++ b/spec/url_canonicalize/destination_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+describe URLCanonicalize::Destination do
+  subject(:resolve) { destination_class.resolve(uri, options) }
+
+  let(:destination_class) { described_class }
+  let(:uri) { URI('http://example.com') }
+  let(:options) { URLCanonicalize::Options.new }
+  let(:addresses) { [addrinfo('93.184.216.34')] }
+
+  before do
+    allow(Addrinfo).to receive(:getaddrinfo)
+      .with(uri.host, uri.port, nil, Socket::SOCK_STREAM)
+      .and_return(addresses)
+  end
+
+  def addrinfo(address, port = 80)
+    Addrinfo.tcp(address, port)
+  end
+
+  it 'returns a resolved public IPv4 address' do
+    expect(resolve).to eq('93.184.216.34')
+  end
+
+  it 'returns a resolved public IPv6 address' do
+    allow(Addrinfo).to receive(:getaddrinfo)
+      .and_return([addrinfo('2606:2800:220:1:248:1893:25c8:1946')])
+
+    expect(resolve).to eq('2606:2800:220:1:248:1893:25c8:1946')
+  end
+
+  it 'returns an allocated public IPv6 address from a narrower IANA prefix' do
+    allow(Addrinfo).to receive(:getaddrinfo)
+      .and_return([addrinfo('2001:4860:4860::8888')])
+
+    expect(resolve).to eq('2001:4860:4860::8888')
+  end
+
+  [
+    '0.0.0.0',
+    '10.0.0.1',
+    '100.64.0.1',
+    '127.0.0.1',
+    '169.254.169.254',
+    '172.16.0.1',
+    '192.0.2.1',
+    '192.168.0.1',
+    '198.18.0.1',
+    '224.0.0.1',
+    '240.0.0.1',
+    '::',
+    '::1',
+    'fc00::1',
+    'fe80::1',
+    'ff00::1',
+    '2001:db8::1',
+    '2002::1',
+    '2004::1',
+    '2d00::1',
+    '2e00::1',
+    '3000::1',
+    '3800::1',
+    '3c00::1',
+    '3e00::1',
+    '3f00::1',
+    '3ffe::1',
+    '3fff::1',
+    '::ffff:127.0.0.1'
+  ].each do |address|
+    it "rejects the non-public address #{address}" do
+      allow(Addrinfo).to receive(:getaddrinfo).and_return([addrinfo(address)])
+
+      expect { resolve }
+        .to raise_error(URLCanonicalize::Exception::Security, /#{Regexp.escape(address)}/)
+    end
+  end
+
+  it 'rejects a hostname when any resolved address is non-public' do
+    allow(Addrinfo).to receive(:getaddrinfo)
+      .and_return([addrinfo('93.184.216.34'), addrinfo('127.0.0.1')])
+
+    expect { resolve }
+      .to raise_error(URLCanonicalize::Exception::Security, /127\.0\.0\.1/)
+  end
+
+  it 'allows a private address with an explicit opt-in' do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([addrinfo('127.0.0.1')])
+    options = URLCanonicalize::Options.new(allow_private_networks: true)
+
+    expect(destination_class.resolve(uri, options)).to eq('127.0.0.1')
+  end
+
+  it 'rejects userinfo without resolving the hostname' do
+    uri = URI('http://user:secret@example.com')
+    allow(Addrinfo).to receive(:getaddrinfo).and_raise('DNS resolution should not run')
+
+    expect { destination_class.resolve(uri, options) }
+      .to raise_error(URLCanonicalize::Exception::Security, 'URLs containing userinfo are not allowed')
+  end
+
+  it 'rejects a port that is not allowed' do
+    uri = URI('http://example.com:3000')
+
+    expect { destination_class.resolve(uri, options) }
+      .to raise_error(URLCanonicalize::Exception::Security, 'Port 3000 is not allowed')
+  end
+
+  it 'allows an explicitly configured port' do
+    uri = URI('http://example.com:3000')
+    options = URLCanonicalize::Options.new(allowed_ports: [3000])
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([addrinfo('93.184.216.34', 3000)])
+
+    expect(destination_class.resolve(uri, options)).to eq('93.184.216.34')
+  end
+
+  it 'rejects an empty DNS result' do
+    allow(Addrinfo).to receive(:getaddrinfo).and_return([])
+
+    expect { resolve }.to raise_error(SocketError, 'No addresses found for example.com')
+  end
+
+  it 'preserves resolver failures' do
+    allow(Addrinfo).to receive(:getaddrinfo).and_raise(SocketError, 'DNS failed')
+
+    expect { resolve }.to raise_error(SocketError, 'DNS failed')
+  end
+end

--- a/spec/url_canonicalize/http_spec.rb
+++ b/spec/url_canonicalize/http_spec.rb
@@ -44,18 +44,212 @@ describe URLCanonicalize::HTTP do
   end
 
   context 'handling protocols' do
+    let(:resolved_address) { '93.184.216.34' }
+
+    before do
+      allow(URLCanonicalize::Destination).to receive(:resolve).and_return(resolved_address)
+    end
+
     it 'uses SSL' do
       url = 'https://twitter.com'
       http = described_class.new(url).send(:http)
+
       expect(http).to be_use_ssl
-      expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+      expect([http.verify_mode, http.verify_hostname, http.ipaddr]).to eq(
+        [OpenSSL::SSL::VERIFY_PEER, true, resolved_address]
+      )
+      expect(http).not_to be_proxy_from_env
     end
 
     it 'uses HTTP' do
       url = 'http://twitter.com'
       http = described_class.new(url).send(:http)
+
       expect(http).not_to be_use_ssl
       expect(http.verify_mode).to be_nil
+      expect(http.ipaddr).to eq(resolved_address)
+      expect(http).not_to be_proxy_from_env
     end
+
+    it 'configures HTTP operation timeouts' do
+      http = described_class.new(
+        'https://twitter.com',
+        open_timeout: 1,
+        read_timeout: 2,
+        write_timeout: 3
+      ).send(:http)
+
+      expect(http.open_timeout).to eq(1)
+      expect(http.read_timeout).to eq(2)
+      expect(http.write_timeout).to eq(3)
+    end
+
+    it 'pins each new host to its validated address' do
+      operation = described_class.new('https://example.com')
+      first_http = operation.send(:http)
+      allow(URLCanonicalize::Destination).to receive(:resolve).and_return('8.8.8.8')
+
+      operation.url = 'https://example.org'
+      second_http = operation.send(:http)
+
+      expect(first_http.ipaddr).to eq(resolved_address)
+      expect(second_http.ipaddr).to eq('8.8.8.8')
+    end
+
+    it 'creates a new client when the scheme changes on the same port' do
+      operation = described_class.new('http://example.com:443')
+      first_http = operation.send(:http)
+
+      operation.url = 'https://example.com:443'
+      second_http = operation.send(:http)
+
+      expect(second_http).not_to equal(first_http)
+      expect([first_http.use_ssl?, second_http.use_ssl?]).to eq([false, true])
+    end
+
+    it 'rejects userinfo before reusing a client for the same origin' do
+      operation = described_class.new('https://example.com')
+      operation.send(:http)
+
+      operation.url = 'https://user:secret@example.com/private'
+
+      expect { operation.send(:http) }.to raise_error(
+        URLCanonicalize::Exception::Security,
+        'URLs containing userinfo are not allowed'
+      )
+    end
+  end
+
+  context 'when streaming response bodies' do
+    let(:operation) { described_class.new('https://example.com', max_body_bytes: 5) }
+    let(:client) { operation.send(:http) }
+
+    before do
+      allow(URLCanonicalize::Destination).to receive(:resolve).and_return('93.184.216.34')
+    end
+
+    it 'rejects an oversized Content-Length before reading the body' do
+      request = Net::HTTP::Get.new('https://example.com')
+      response = response_with(content_type: 'text/html', content_length: 6)
+      allow(response).to receive(:read_body) { raise 'body should not be read' }
+      stub_response(client, request, response)
+
+      expect { operation.do_request(request) }.to raise_error(
+        URLCanonicalize::Exception::ResponseTooLarge,
+        'Response body exceeds 5 bytes'
+      )
+    end
+
+    it 'rejects a chunk that crosses the byte limit' do
+      request = Net::HTTP::Get.new('https://example.com')
+      response = response_with(content_type: 'text/html')
+      buffered_body = stub_response(client, request, response, chunks: %w[1234 56])
+
+      expect { operation.do_request(request) }.to raise_error(URLCanonicalize::Exception::ResponseTooLarge)
+      expect(buffered_body.call).to eq('1234')
+    end
+
+    [
+      'text/html',
+      'Text/HTML; Charset=UTF-8',
+      'application/xhtml+xml',
+      'application/xml',
+      'text/xml'
+    ].each do |content_type|
+      it "buffers #{content_type}" do
+        request = Net::HTTP::Get.new('https://example.com')
+        response = response_with(content_type:)
+        buffered_body = stub_response(client, request, response, chunks: %w[12 345])
+
+        operation.do_request(request)
+
+        expect(buffered_body.call).to eq('12345')
+      end
+    end
+
+    it 'discards unsupported media types without buffering them' do
+      request = Net::HTTP::Get.new('https://example.com')
+      response = response_with(content_type: 'application/octet-stream')
+      buffered_body = stub_response(client, request, response, chunks: ['123456'])
+
+      operation.do_request(request)
+
+      expect(buffered_body.call).to be_nil
+    end
+
+    it 'does not buffer HEAD response bodies' do
+      request = Net::HTTP::Head.new('https://example.com')
+      response = response_with(content_type: 'text/html')
+      buffered_body = stub_response(client, request, response, chunks: ['123456'])
+
+      operation.do_request(request)
+
+      expect(buffered_body.call).to be_nil
+    end
+
+    it 'does not buffer redirect response bodies' do
+      request = Net::HTTP::Get.new('https://example.com')
+      response = response_with(response_class: Net::HTTPMovedPermanently, content_type: 'text/html')
+      buffered_body = stub_response(client, request, response, chunks: ['123456'])
+
+      operation.do_request(request)
+
+      expect(buffered_body.call).to be_nil
+    end
+  end
+
+  context 'when enforcing the total deadline' do
+    let(:url) { 'https://example.com' }
+    let(:request) { instance_double(URLCanonicalize::Request) }
+
+    before do
+      allow(URLCanonicalize::Request).to receive(:new).and_return(request)
+      allow(request).to receive(:with_uri).and_return(request)
+    end
+
+    it 'raises a specific timeout error when the operation exceeds its deadline' do
+      allow(request).to receive(:fetch) { sleep 0.05 }
+
+      expect { described_class.new(url, total_timeout: 0.01).fetch }.to raise_error(
+        URLCanonicalize::Exception::Timeout,
+        'Canonicalization exceeded 0.01 seconds'
+      )
+    end
+
+    it 'uses one deadline across multiple hops' do
+      timeout_calls = 0
+      responses = [
+        URLCanonicalize::Response::Redirect.new("#{url}/redirect"),
+        URLCanonicalize::Response::Success.new("#{url}/final", '', '')
+      ]
+      allow(request).to receive(:fetch).and_return(*responses)
+      allow(Timeout).to receive(:timeout) do |*_arguments, &operation|
+        timeout_calls += 1
+        operation.call
+      end
+
+      expect(described_class.new(url, total_timeout: 0.05).fetch)
+        .to be_a(URLCanonicalize::Response::Success)
+      expect(timeout_calls).to eq(1)
+    end
+  end
+
+  def response_with(content_type:, response_class: Net::HTTPOK, content_length: nil)
+    code = Net::HTTPResponse::CODE_TO_OBJ.key(response_class)
+    response = response_class.new('1.1', code, '')
+    response['Content-Type'] = content_type
+    response['Content-Length'] = content_length.to_s if content_length
+    response
+  end
+
+  def stub_response(client, request, response, chunks: [])
+    buffered_body = nil
+    allow(response).to receive(:read_body) do |destination = nil, &block|
+      buffered_body = destination
+      chunks.each { |chunk| destination ? destination << chunk : block.call(chunk) }
+    end
+    allow(client).to receive(:request).with(request).and_yield(response).and_return(response)
+
+    -> { buffered_body }
   end
 end

--- a/spec/url_canonicalize/http_spec.rb
+++ b/spec/url_canonicalize/http_spec.rb
@@ -31,14 +31,49 @@ describe URLCanonicalize::HTTP do
     end
 
     it 'detects a redirect loop' do
-      responses = [url, "#{url}xxx", url].map { |u| URLCanonicalize::Response::Redirect.new(u) }
+      responses = ["#{url}/a", "#{url}/b", "#{url}/a"].map { |u| URLCanonicalize::Response::Redirect.new(u) }
       expect(fetch_double).to receive(:fetch).exactly(3).times.and_return(*responses)
+      expect { http.fetch }.to raise_error(URLCanonicalize::Exception::Redirect, 'Redirect loop detected')
+    end
+
+    it 'detects a redirect straight back to the original URL' do
+      expect(fetch_double).to receive(:fetch).once.and_return(URLCanonicalize::Response::Redirect.new(url))
       expect { http.fetch }.to raise_error(URLCanonicalize::Exception::Redirect, 'Redirect loop detected')
     end
 
     it 'handles a canonical URL different to the called URL' do
       responses = [URLCanonicalize::Response::CanonicalFound.new('http://new.url', response), response]
       expect(fetch_double).to receive(:fetch).twice.and_return(*responses)
+      expect(http.fetch).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'terminates a canonical link cycle deterministically' do
+      other_url = "#{url}/other"
+      responses = [
+        URLCanonicalize::Response::CanonicalFound.new(other_url, response),
+        URLCanonicalize::Response::CanonicalFound.new(url, response)
+      ]
+      expect(fetch_double).to receive(:fetch).twice.and_return(*responses)
+      expect(http.fetch).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'counts followed canonical links against the hop budget' do
+      http = described_class.new(url, max_redirects: 2)
+      responses = (1..3).map do |i|
+        URLCanonicalize::Response::CanonicalFound.new("#{url}/#{i}", response)
+      end
+      expect(fetch_double).to receive(:fetch).exactly(3).times.and_return(*responses)
+      expect(http.fetch).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'shares one hop budget between redirects and canonical links' do
+      http = described_class.new(url, max_redirects: 2)
+      responses = [
+        URLCanonicalize::Response::Redirect.new("#{url}/1"),
+        URLCanonicalize::Response::CanonicalFound.new("#{url}/2", response),
+        URLCanonicalize::Response::Redirect.new("#{url}/3")
+      ]
+      expect(fetch_double).to receive(:fetch).exactly(3).times.and_return(*responses)
       expect(http.fetch).to be_a(URLCanonicalize::Response::Success)
     end
   end

--- a/spec/url_canonicalize/http_spec.rb
+++ b/spec/url_canonicalize/http_spec.rb
@@ -166,7 +166,7 @@ describe URLCanonicalize::HTTP do
     it 'rejects an oversized Content-Length before reading the body' do
       request = Net::HTTP::Get.new('https://example.com')
       response = response_with(content_type: 'text/html', content_length: 6)
-      allow(response).to receive(:read_body) { raise 'body should not be read' }
+      allow(response).to receive(:read_body) { raise IOError, 'body should not be read' }
       stub_response(client, request, response)
 
       expect { operation.do_request(request) }.to raise_error(

--- a/spec/url_canonicalize/link_header_spec.rb
+++ b/spec/url_canonicalize/link_header_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe URLCanonicalize::LinkHeader do
+  def response_with_links(*fields)
+    response = Net::HTTPOK.new('1.1', '200', '')
+    fields.each { |field| response.add_field('Link', field) }
+    response
+  end
+
+  it 'finds a canonical link with a quoted rel' do
+    response = response_with_links('<https://example.com/>; rel="canonical"')
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'finds a canonical link with an unquoted rel' do
+    response = response_with_links('<https://example.com/>; rel=canonical')
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'matches rel values case-insensitively' do
+    response = response_with_links('<https://example.com/>; REL="Canonical"')
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'matches canonical within a list of rel tokens' do
+    response = response_with_links('<https://example.com/>; rel="canonical nofollow"')
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'does not match rel tokens that merely contain canonical' do
+    response = response_with_links('<https://example.com/>; rel="not-canonical"')
+    expect(described_class.canonical(response)).to be_nil
+  end
+
+  it 'finds the canonical link among multiple links in one header' do
+    response = response_with_links(
+      '<https://example.com/style.css>; rel="stylesheet", <https://example.com/>; rel="canonical"'
+    )
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'finds the canonical link across multiple Link headers' do
+    response = response_with_links(
+      '<https://example.com/alternate>; rel="alternate"',
+      '<https://example.com/>; rel="canonical"'
+    )
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'is not confused by quoted parameters containing commas or angle brackets' do
+    response = response_with_links(
+      '<https://example.com/other>; title="a, <b>"; rel="alternate", <https://example.com/>; rel="canonical"'
+    )
+    expect(described_class.canonical(response)).to eq('https://example.com/')
+  end
+
+  it 'returns nil when no link is canonical' do
+    response = response_with_links('<https://example.com/alternate>; rel="alternate"')
+    expect(described_class.canonical(response)).to be_nil
+  end
+
+  it 'returns nil when a link has no rel parameter' do
+    response = response_with_links('<https://example.com/>')
+    expect(described_class.canonical(response)).to be_nil
+  end
+
+  it 'returns nil when there is no Link header' do
+    expect(described_class.canonical(Net::HTTPOK.new('1.1', '200', ''))).to be_nil
+  end
+end

--- a/spec/url_canonicalize/options_spec.rb
+++ b/spec/url_canonicalize/options_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+describe URLCanonicalize::Options do
+  subject(:options) { options_class.new }
+
+  let(:options_class) { described_class }
+  let(:overrides) do
+    {
+      allow_private_networks: true,
+      allowed_ports: [3000],
+      max_body_bytes: 2048,
+      total_timeout: 10,
+      open_timeout: 2,
+      read_timeout: 3,
+      write_timeout: 4,
+      max_redirects: 5
+    }
+  end
+
+  it 'uses secure defaults' do
+    expect(options.to_h).to include(
+      allow_private_networks: false,
+      allowed_ports: [80, 443],
+      max_body_bytes: 1_048_576,
+      total_timeout: 30,
+      open_timeout: 8,
+      read_timeout: 15,
+      write_timeout: 8,
+      max_redirects: 10
+    )
+  end
+
+  it 'accepts supported overrides' do
+    expect(options_class.new(**overrides).to_h).to eq(overrides)
+  end
+
+  it 'rejects unknown options' do
+    expect { options_class.new(unknown: true) }
+      .to raise_error(ArgumentError, 'Unknown options: unknown')
+  end
+
+  it 'rejects non-positive limits' do
+    %i[max_body_bytes total_timeout open_timeout read_timeout write_timeout max_redirects].each do |name|
+      expect { options_class.new(name => 0) }
+        .to raise_error(ArgumentError, "#{name} must be positive")
+    end
+  end
+
+  it 'rejects invalid ports' do
+    expect { options_class.new(allowed_ports: [0, 65_536]) }
+      .to raise_error(ArgumentError, 'allowed_ports must contain only valid TCP ports')
+  end
+
+  it 'rejects non-boolean private network settings' do
+    expect { options_class.new(allow_private_networks: 'yes') }
+      .to raise_error(ArgumentError, 'allow_private_networks must be true or false')
+  end
+
+  it 'returns defensive copies of mutable values' do
+    values = options.to_h
+    values[:allowed_ports] << 3000
+
+    expect(options[:allowed_ports]).to eq([80, 443])
+  end
+
+  describe URLCanonicalize do
+    context 'when fetching a URL' do
+      it 'forwards security options to the HTTP operation' do
+        expect { described_class.fetch('https://example.com', unknown: true) }
+          .to raise_error(ArgumentError, 'Unknown options: unknown')
+      end
+    end
+  end
+end

--- a/spec/url_canonicalize/request_spec.rb
+++ b/spec/url_canonicalize/request_spec.rb
@@ -411,7 +411,7 @@ describe URLCanonicalize::Request do
           stub_request(:any, url).to_return(status: [http_code_from(klass), message])
           expect_exception URLCanonicalize::Exception::Failure, test
         else
-          expect(true).to be_false
+          raise ArgumentError, "Unhandled outcome: #{outcome.inspect}"
         end
       end
     end

--- a/spec/url_canonicalize/request_spec.rb
+++ b/spec/url_canonicalize/request_spec.rb
@@ -2,19 +2,68 @@
 
 describe URLCanonicalize::Request do
   context 'response types' do
-    it 'follows temporary redirections' do
+    {
+      '301' => Net::HTTPMovedPermanently,
+      '302' => Net::HTTPFound,
+      '303' => Net::HTTPSeeOther,
+      '307' => Net::HTTPTemporaryRedirect,
+      '308' => Net::HTTPPermanentRedirect
+    }.each do |code, response_class|
+      it "follows a #{code} redirection" do
+        url = 'http://twitter.com'
+        location = 'https://twitter.com/'
+        http = URLCanonicalize::HTTP.new(url)
+        request = described_class.new(http)
+        response = response_class.new('1.1', code, '')
+        response['location'] = location
+
+        allow(request).to receive(:do_http_request).and_return(response)
+
+        result = request.with_uri(URLCanonicalize::URI.parse(url)).fetch
+
+        expect(result).to be_a(URLCanonicalize::Response::Redirect)
+        expect(result.url).to eq(location)
+      end
+    end
+
+    it 'resolves a protocol-relative redirect location' do
+      result = redirect_from('https://twitter.com', location: '//other.example/path')
+
+      expect(result).to be_a(URLCanonicalize::Response::Redirect)
+      expect(result.url).to eq('https://other.example/path')
+    end
+
+    it 'resolves a query-only redirect location' do
+      result = redirect_from('http://twitter.com/page', location: '?q=1')
+
+      expect(result).to be_a(URLCanonicalize::Response::Redirect)
+      expect(result.url).to eq('http://twitter.com/page?q=1')
+    end
+
+    it 'treats a redirect to a non-HTTP location as a failure' do
+      expect(redirect_from('http://twitter.com', location: 'ftp://example.com/file'))
+        .to be_a(URLCanonicalize::Response::Failure)
+    end
+
+    def redirect_from(url, location:)
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+      response = Net::HTTPMovedPermanently.new('1.1', '301', '')
+      response['location'] = location
+      allow(request).to receive(:do_http_request).and_return(response)
+      request.with_uri(URLCanonicalize::URI.parse(url)).fetch
+    end
+
+    it 'treats a redirection without a Location header as a failure' do
       url = 'http://twitter.com'
       http = URLCanonicalize::HTTP.new(url)
       request = described_class.new(http)
-      responses = [
-        Net::HTTPFound.new('1.1', '302', ''),
-        Net::HTTPOK.new('1.1', '200', '')
-      ]
+      response = Net::HTTPFound.new('1.1', '302', '')
 
-      allow(request).to receive(:do_http_request).and_return(*responses)
+      allow(request).to receive(:do_http_request).and_return(response)
 
       expect(request.with_uri(URLCanonicalize::URI.parse(url)).fetch)
-        .to be_a(URLCanonicalize::Response::Success)
+        .to be_a(URLCanonicalize::Response::Failure)
     end
 
     it 'logs the response if required' do
@@ -90,10 +139,121 @@ describe URLCanonicalize::Request do
       response['Content-Type'] = 'text/html; charset=utf-8'
 
       expect(URLCanonicalize::HTTP).to receive(:new).and_return(http)
-      expect(response).to receive(:body).and_return(html, '')
-      expect(http).to receive(:do_request).twice.and_return(response)
+      expect(response).to receive(:body).and_return(html, '', '')
+      expect(http).to receive(:do_request).exactly(3).times.and_return(response)
 
       expect(URLCanonicalize.canonicalize(url)).to eq(canonical_url)
+    end
+
+    it 'finds the canonical link among multiple links in a Link header' do
+      url = 'http://twitter.com'
+      canonical_url = 'https://twitter.com/canonical'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+      response = Net::HTTPOK.new('1.1', '200', '')
+      response['Link'] = "<https://twitter.com/style.css>; rel=\"stylesheet\", <#{canonical_url}>; rel=\"canonical\""
+
+      allow(request).to receive(:do_http_request).and_return(response)
+
+      result = request.with_uri(URLCanonicalize::URI.parse(url)).fetch
+
+      expect(result).to be_a(URLCanonicalize::Response::CanonicalFound)
+      expect(result.url).to eq(canonical_url)
+    end
+
+    it 'resolves a relative canonical Link target against the request URL' do
+      url = 'http://twitter.com'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+      response = Net::HTTPOK.new('1.1', '200', '')
+      response['Link'] = '</canonical>; rel=canonical'
+
+      allow(request).to receive(:do_http_request).and_return(response)
+
+      result = request.with_uri(URLCanonicalize::URI.parse(url)).fetch
+
+      expect(result).to be_a(URLCanonicalize::Response::CanonicalFound)
+      expect(result.url).to eq('http://twitter.com/canonical')
+    end
+
+    it 'does not leak canonical state to the next URI' do
+      url = 'http://twitter.com'
+      canonical_url = 'https://twitter.com/'
+      html = "<html><head><link rel=\"canonical\" href=\"#{canonical_url}\" /></head></html>"
+
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+
+      with_canonical = Net::HTTPOK.new('1.1', '200', '')
+      with_canonical['Content-Type'] = 'text/html'
+      allow(with_canonical).to receive(:body).and_return(html)
+
+      plain = Net::HTTPOK.new('1.1', '200', '')
+      plain['Content-Type'] = 'text/html'
+      allow(plain).to receive(:body).and_return('<html><head></head></html>')
+
+      allow(request).to receive(:do_http_request).and_return(with_canonical, plain, plain)
+
+      expect(request.with_uri(URLCanonicalize::URI.parse(url)).fetch)
+        .to be_a(URLCanonicalize::Response::CanonicalFound)
+      expect(request.with_uri(URLCanonicalize::URI.parse(canonical_url)).fetch)
+        .to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'resets the HTTP method for each new URI' do
+      url = 'http://twitter.com'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+      plain = Net::HTTPOK.new('1.1', '200', '')
+      allow(plain).to receive(:body).and_return('')
+      allow(request).to receive(:do_http_request).and_return(plain)
+
+      request.with_uri(URLCanonicalize::URI.parse(url)).fetch
+      expect(request.send(:http_method)).to eq(:get)
+
+      request.with_uri(URLCanonicalize::URI.parse('https://twitter.com/'))
+      expect(request.send(:http_method)).to eq(:head)
+    end
+
+    it 'recognizes HTML canonical links case-insensitively' do
+      html = '<html><head><link rel="Canonical" href="https://twitter.com/x" /></head></html>'
+      result = html_success_request(html).fetch
+
+      expect(result).to be_a(URLCanonicalize::Response::CanonicalFound)
+      expect(result.url).to eq('https://twitter.com/x')
+    end
+
+    it 'recognizes canonical among multiple rel tokens' do
+      html = '<html><head><link rel="canonical nofollow" href="https://twitter.com/x" /></head></html>'
+      result = html_success_request(html).fetch
+
+      expect(result).to be_a(URLCanonicalize::Response::CanonicalFound)
+      expect(result.url).to eq('https://twitter.com/x')
+    end
+
+    it 'resolves an HTML canonical link against the document base URL' do
+      html = '<html><head><base href="https://base.example/dir/">' \
+             '<link rel="canonical" href="page"></head></html>'
+      result = html_success_request(html).fetch
+
+      expect(result).to be_a(URLCanonicalize::Response::CanonicalFound)
+      expect(result.url).to eq('https://base.example/dir/page')
+    end
+
+    it 'ignores a canonical link without a usable href' do
+      html = '<html><head><link rel="canonical" href=" " /></head></html>'
+
+      expect(html_success_request(html).fetch).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    def html_success_request(html, url: 'http://twitter.com')
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+      response = Net::HTTPOK.new('1.1', '200', '')
+      response['Content-Type'] = 'text/html'
+      allow(response).to receive(:body).and_return(html)
+      allow(request).to receive(:do_http_request).and_return(response)
+      request.with_uri(URLCanonicalize::URI.parse(url))
     end
 
     it 'does not parse non-HTML successful responses as HTML' do
@@ -111,6 +271,47 @@ describe URLCanonicalize::Request do
     end
   end
 
+  context 'HEAD fallback' do
+    {
+      '403' => Net::HTTPForbidden,
+      '405' => Net::HTTPMethodNotAllowed,
+      '501' => Net::HTTPNotImplemented
+    }.each do |code, response_class|
+      it "retries a HEAD request rejected with #{code} as a GET" do
+        url = 'http://twitter.com'
+        http = URLCanonicalize::HTTP.new(url)
+        request = described_class.new(http)
+        rejection = response_class.new('1.1', code, '')
+        ok = Net::HTTPOK.new('1.1', '200', '')
+
+        expect(request).to receive(:do_http_request).twice.and_return(rejection, ok)
+
+        expect(request.with_uri(URLCanonicalize::URI.parse(url)).fetch)
+          .to be_a(URLCanonicalize::Response::Success)
+      end
+    end
+
+    it 'does not retry an unsuccessful GET request' do
+      url = 'http://twitter.com'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
+      rejection = Net::HTTPMethodNotAllowed.new('1.1', '405', '')
+
+      expect(request).to receive(:do_http_request).twice.and_return(rejection, rejection)
+
+      expect(request.with_uri(URLCanonicalize::URI.parse(url)).fetch)
+        .to be_a(URLCanonicalize::Response::Failure)
+    end
+
+    it 'uses HEAD first for every host' do
+      url = 'https://www.linkedin.com/company/example'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http).with_uri(URLCanonicalize::URI.parse(url))
+
+      expect(request.send(:request).method).to eq('HEAD')
+    end
+  end
+
   context 'HTTP method' do
     it 'handles invalid HTTP methods' do
       http = URLCanonicalize::HTTP.new('http://twitter.com')
@@ -124,6 +325,15 @@ describe URLCanonicalize::Request do
     before do
       allow(Addrinfo).to receive(:getaddrinfo)
         .and_return([Addrinfo.tcp('93.184.216.34', 80)])
+    end
+
+    it 'preserves the original network error as the cause of the raised failure' do
+      url = 'http://twitter.com'
+      stub_request(:any, url).to_raise(SocketError.new('getaddrinfo: Name or service not known'))
+
+      expect { URLCanonicalize.fetch(url) }.to raise_error(URLCanonicalize::Exception::Failure) do |exception|
+        expect(exception.cause).to be_a(SocketError)
+      end
     end
 
     # Recent versions of URI do not barf when asked to parse http://$$$, http://_ or http://~ so I've commented those out

--- a/spec/url_canonicalize/request_spec.rb
+++ b/spec/url_canonicalize/request_spec.rb
@@ -3,26 +3,36 @@
 describe URLCanonicalize::Request do
   context 'response types' do
     it 'follows temporary redirections' do
+      url = 'http://twitter.com'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
       responses = [
         Net::HTTPFound.new('1.1', '302', ''),
         Net::HTTPOK.new('1.1', '200', '')
       ]
 
-      responses.each { |response| expect(response).to receive(:body).and_return('') }
-      expect_any_instance_of(described_class).to receive(:do_http_request).and_return(*responses)
-      URLCanonicalize.fetch('http://twitter.com')
+      allow(request).to receive(:do_http_request).and_return(*responses)
+
+      expect(request.with_uri(URLCanonicalize::URI.parse(url)).fetch)
+        .to be_a(URLCanonicalize::Response::Success)
     end
 
     it 'logs the response if required' do
+      url = 'https://twitter.com'
+      http = URLCanonicalize::HTTP.new(url)
+      request = described_class.new(http)
       responses = [
         Net::HTTPOK.new('1.1', '200', ''),
         Net::HTTPOK.new('1.1', '200', '')
       ]
 
       ENV['DEBUG'] = 'true'
-      responses.each { |response| expect(response).to receive(:body).and_return('') }
-      expect_any_instance_of(described_class).to receive(:do_http_request).and_return(*responses)
-      URLCanonicalize.fetch('https://twitter.com')
+      allow(request).to receive(:do_http_request).and_return(*responses)
+
+      expect { request.with_uri(URLCanonicalize::URI.parse(url)).fetch }
+        .to output(%r{GET https://twitter.com 200}).to_stdout
+    ensure
+      ENV.delete('DEBUG')
     end
 
     it 'follows permanent redirections' do
@@ -34,7 +44,6 @@ describe URLCanonicalize::Request do
       response['location'] = canonical_url
       canonical_response = Net::HTTPOK.new('1.1', '200', '')
 
-      expect(canonical_response).to receive(:body).twice.and_return('')
       expect(URLCanonicalize::HTTP).to receive(:new).and_return(http)
       expect(http).to receive(:do_request).and_return(response, canonical_response, canonical_response)
 
@@ -51,7 +60,6 @@ describe URLCanonicalize::Request do
       response['location'] = relative_path
       canonical_response = Net::HTTPOK.new('1.1', '200', '')
 
-      expect(canonical_response).to receive(:body).twice.and_return('')
       expect(URLCanonicalize::HTTP).to receive(:new).and_return(http)
       expect(http).to receive(:do_request).and_return(response, canonical_response, canonical_response)
 
@@ -79,12 +87,27 @@ describe URLCanonicalize::Request do
 
       http = URLCanonicalize::HTTP.new(url)
       response = Net::HTTPOK.new('1.1', '200', '')
+      response['Content-Type'] = 'text/html; charset=utf-8'
 
       expect(URLCanonicalize::HTTP).to receive(:new).and_return(http)
       expect(response).to receive(:body).and_return(html, '')
       expect(http).to receive(:do_request).twice.and_return(response)
 
       expect(URLCanonicalize.canonicalize(url)).to eq(canonical_url)
+    end
+
+    it 'does not parse non-HTML successful responses as HTML' do
+      url = 'https://example.com/data'
+      http = URLCanonicalize::HTTP.new(url)
+      response = Net::HTTPOK.new('1.1', '200', '')
+      response['Content-Type'] = 'application/xml'
+
+      allow(response).to receive(:body).and_return('<root />')
+      allow(http).to receive(:do_request).and_return(response)
+
+      result = described_class.new(http).with_uri(URLCanonicalize::URI.parse(url)).fetch
+
+      expect(result.html).to be_nil
     end
   end
 
@@ -98,6 +121,11 @@ describe URLCanonicalize::Request do
   end
 
   context 'real world examples' do
+    before do
+      allow(Addrinfo).to receive(:getaddrinfo)
+        .and_return([Addrinfo.tcp('93.184.216.34', 80)])
+    end
+
     # Recent versions of URI do not barf when asked to parse http://$$$, http://_ or http://~ so I've commented those out
     # examples
     [

--- a/spec/url_canonicalize/request_spec.rb
+++ b/spec/url_canonicalize/request_spec.rb
@@ -66,22 +66,48 @@ describe URLCanonicalize::Request do
         .to be_a(URLCanonicalize::Response::Failure)
     end
 
-    it 'logs the response if required' do
-      url = 'https://twitter.com'
-      http = URLCanonicalize::HTTP.new(url)
-      request = described_class.new(http)
-      responses = [
-        Net::HTTPOK.new('1.1', '200', ''),
-        Net::HTTPOK.new('1.1', '200', '')
-      ]
+    context 'with debug logging' do
+      let(:url) { 'https://twitter.com' }
+      let(:http) { URLCanonicalize::HTTP.new(url) }
+      let(:request) { described_class.new(http) }
+      let(:response) do
+        r = Net::HTTPOK.new('1.1', '200', '')
+        r['Content-Type'] = 'text/html'
+        allow(r).to receive(:body).and_return('')
+        r
+      end
 
-      ENV['DEBUG'] = 'true'
-      allow(request).to receive(:do_http_request).and_return(*responses)
+      before { allow(request).to receive(:do_http_request).and_return(response) }
 
-      expect { request.with_uri(URLCanonicalize::URI.parse(url)).fetch }
-        .to output(%r{GET https://twitter.com 200}).to_stdout
-    ensure
-      ENV.delete('DEBUG')
+      def fetch
+        request.with_uri(URLCanonicalize::URI.parse(url)).fetch
+      end
+
+      it 'logs the response if required' do
+        with_env('DEBUG', 'true') do
+          expect { fetch }.to output(%r{GET https://twitter.com 200}).to_stdout
+        end
+      end
+
+      it 'logs response headers when DEBUG is headers' do
+        with_env('DEBUG', 'headers') do
+          expect { fetch }.to output(%r{content-type:\ttext/html}i).to_stdout
+        end
+      end
+
+      it 'does not log response headers for other DEBUG values' do
+        with_env('DEBUG', 'true') do
+          expect { fetch }.not_to output(/content-type/i).to_stdout
+        end
+      end
+
+      it 'logs a found canonical URL if required' do
+        response['Link'] = '<https://twitter.com/canonical>; rel="canonical"'
+
+        with_env('DEBUG', 'true') do
+          expect { fetch }.to output(%r{canonical_url:\thttps://twitter.com/canonical}).to_stdout
+        end
+      end
     end
 
     it 'follows permanent redirections' do
@@ -368,7 +394,7 @@ describe URLCanonicalize::Request do
       # { url: 'http://_',                    outcome: :exception_uri,          message: 'URI::InvalidURIError: the scheme http does not accept registry part: _ (or bad hostname?)' },
       { url: 'http://www.twitter.com',      outcome: :success }
       # { url: 'http://~',                    outcome: :exception_uri, message: 'URI::InvalidURIError: the scheme http does not accept registry part: ~ (or bad hostname?)' }
-    ].shuffle.each do |test|
+    ].each do |test|
       it 'handles real-world data' do
         url, outcome, message, klass = *test.values
 

--- a/spec/url_canonicalize/response_spec.rb
+++ b/spec/url_canonicalize/response_spec.rb
@@ -39,6 +39,13 @@ describe URLCanonicalize::Response::Redirect do
       response = described_class.new('failure_class', 'message')
       expect(response.failure_class).to eq('failure_class')
       expect(response.message).to eq('message')
+      expect(response.error).to be_nil
+    end
+
+    it 'carries the original error when there is one' do
+      error = SocketError.new('getaddrinfo: Name or service not known')
+      response = described_class.new(SocketError, 'message', error)
+      expect(response.error).to be(error)
     end
   end
 end

--- a/spec/url_canonicalize/uri_spec.rb
+++ b/spec/url_canonicalize/uri_spec.rb
@@ -43,4 +43,10 @@ describe URLCanonicalize::URI do
       URLCanonicalize::Exception::URI, 'URI::InvalidURIError: URI must be ascii only "http://\xFF"'
     )
   end
+
+  it 'preserves the original parsing error as the cause' do
+    expect { described_class.parse("http://\xFF") }.to raise_error(URLCanonicalize::Exception::URI) do |exception|
+      expect(exception.cause).to be_a(URI::InvalidURIError)
+    end
+  end
 end

--- a/spec/url_canonicalize_spec.rb
+++ b/spec/url_canonicalize_spec.rb
@@ -119,6 +119,78 @@ describe URLCanonicalize do
     end
   end
 
+  context 'when following redirects and canonical links at the HTTP boundary' do
+    let(:public_address) { '93.184.216.34' }
+
+    before do
+      allow(Addrinfo).to receive(:getaddrinfo) do |_host, port, *_arguments|
+        [Addrinfo.tcp(public_address, port)]
+      end
+    end
+
+    it 'follows a chain of redirects, resolving each Location form' do
+      stub_request(:head, 'http://start.test/')
+        .to_return(status: 301, headers: { 'Location' => 'https://middle.test/a' })
+      stub_request(:head, 'https://middle.test/a')
+        .to_return(status: 302, headers: { 'Location' => '//final.test/b' })
+      stub_request(:head, 'https://final.test/b').to_return(status: 200)
+      stub_request(:get, 'https://final.test/b').to_return(status: 200)
+
+      expect(described_class.canonicalize('http://start.test')).to eq('https://final.test/b')
+    end
+
+    it 'follows a canonical Link header and falls back to the last known good response when its target fails' do
+      stub_request(:head, 'https://site.test/page')
+        .to_return(status: 200, headers: { 'Link' => '</canonical>; rel=canonical' })
+      stub_request(:head, 'https://site.test/canonical').to_raise(SocketError)
+
+      expect(described_class.canonicalize('https://site.test/page')).to eq('https://site.test/canonical')
+    end
+
+    it 'discovers a canonical link in the HTML head and resolves it against the document base URL' do
+      html = '<html><head><base href="https://cdn.test/dir/"><link rel="Canonical" href="page"></head></html>'
+      stub_request(:head, 'https://site.test/article').to_return(status: 200)
+      stub_request(:get, 'https://site.test/article')
+        .to_return(status: 200, body: html, headers: { 'Content-Type' => 'text/html' })
+      stub_request(:head, 'https://cdn.test/dir/page').to_return(status: 200)
+      stub_request(:get, 'https://cdn.test/dir/page').to_return(status: 200)
+
+      expect(described_class.canonicalize('https://site.test/article')).to eq('https://cdn.test/dir/page')
+    end
+
+    it 'raises when redirects form a loop' do
+      stub_request(:head, 'https://loop.test/a').to_return(status: 302, headers: { 'Location' => '/b' })
+      stub_request(:head, 'https://loop.test/b').to_return(status: 302, headers: { 'Location' => '/a' })
+
+      expect { described_class.fetch('https://loop.test/a') }
+        .to raise_error(URLCanonicalize::Exception::Redirect, 'Redirect loop detected')
+    end
+
+    it 'raises when the hop budget is exhausted' do
+      stub_request(:head, 'https://deep.test/1').to_return(status: 301, headers: { 'Location' => '/2' })
+      stub_request(:head, 'https://deep.test/2').to_return(status: 301, headers: { 'Location' => '/3' })
+
+      expect { described_class.fetch('https://deep.test/1', max_redirects: 1) }
+        .to raise_error(URLCanonicalize::Exception::Redirect, '2 redirects is too many')
+    end
+
+    it 'retries a rejected HEAD request as a GET' do
+      stub_request(:head, 'https://nohead.test/').to_return(status: 405)
+      stub_request(:get, 'https://nohead.test/').to_return(status: 200)
+
+      expect(described_class.fetch('https://nohead.test')).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'rejects a response body that exceeds the size limit' do
+      stub_request(:head, 'https://big.test/').to_return(status: 200)
+      stub_request(:get, 'https://big.test/')
+        .to_return(status: 200, body: 'x' * 10, headers: { 'Content-Type' => 'text/html' })
+
+      expect { described_class.fetch('https://big.test', max_body_bytes: 5) }
+        .to raise_error(URLCanonicalize::Exception::ResponseTooLarge)
+    end
+  end
+
   def stub_dns(hosts)
     allow(Addrinfo).to receive(:getaddrinfo) do |host, port, *_arguments|
       [Addrinfo.tcp(hosts.fetch(host), port)]

--- a/spec/url_canonicalize_spec.rb
+++ b/spec/url_canonicalize_spec.rb
@@ -1,27 +1,127 @@
 # frozen_string_literal: true
 
 describe URLCanonicalize do
-  let(:host) { 'www.twitter.com' }
-  let(:protocol) { 'https' }
-  let(:url) { "#{protocol}://#{host}" }
-  let(:response) { URLCanonicalize::Response::Success.new(url, '', '') }
+  context 'when delegating through the public API' do
+    let(:host) { 'www.twitter.com' }
+    let(:protocol) { 'https' }
+    let(:url) { "#{protocol}://#{host}" }
+    let(:response) { URLCanonicalize::Response::Success.new(url, '', '') }
 
-  before do
-    fetch_double = double
-    expect(URLCanonicalize::Request).to receive(:new).once.and_return(fetch_double)
-    expect(fetch_double).to receive(:fetch).and_return(response)
-    expect(fetch_double).to receive(:with_uri).and_return(fetch_double)
+    before do
+      fetch_double = instance_double(URLCanonicalize::Request)
+      allow(URLCanonicalize::Request).to receive(:new).and_return(fetch_double)
+      allow(fetch_double).to receive_messages(fetch: response, with_uri: fetch_double)
+    end
+
+    it 'returns successfully for a complete URL' do
+      expect(described_class.fetch(url)).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'returns successfully for a host name' do
+      expect(described_class.fetch(host)).to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'canonicalizes a URL' do
+      expect(url.canonicalize).to eq(url)
+    end
   end
 
-  it 'returns successfully for a complete URL' do
-    expect(described_class.fetch(url)).to be_a(URLCanonicalize::Response::Success)
+  context 'when fetching a complete URL chain' do
+    let(:public_address) { '93.184.216.34' }
+
+    it 'blocks a prohibited initial destination' do
+      stub_dns('blocked.test' => '127.0.0.1')
+
+      expect { described_class.fetch('http://blocked.test') }.to raise_error(
+        URLCanonicalize::Exception::Security,
+        /127\.0\.0\.1/
+      )
+    end
+
+    it 'blocks a prohibited redirect destination' do
+      initial_url = 'http://public.test/start'
+      blocked_url = 'http://blocked.test/secret'
+      stub_dns('public.test' => public_address, 'blocked.test' => '169.254.169.254')
+      stub_request(:head, initial_url).to_return(status: 301, headers: { 'Location' => blocked_url })
+
+      expect { described_class.fetch(initial_url) }.to raise_error(
+        URLCanonicalize::Exception::Security,
+        /169\.254\.169\.254/
+      )
+    end
+
+    it 'blocks a prohibited HTML canonical destination' do
+      initial_url = 'http://public.test/article'
+      blocked_url = 'http://blocked.test/canonical'
+      html = %(<html><head><link rel="canonical" href="#{blocked_url}"></head></html>)
+      stub_dns('public.test' => public_address, 'blocked.test' => '10.0.0.1')
+      stub_request(:head, initial_url).to_return(status: 200)
+      stub_request(:get, initial_url).to_return(
+        status: 200,
+        headers: { 'Content-Type' => 'text/html' },
+        body: html
+      )
+
+      expect { described_class.fetch(initial_url) }.to raise_error(
+        URLCanonicalize::Exception::Security,
+        /10\.0\.0\.1/
+      )
+    end
+
+    it 'blocks userinfo on a redirect within the same origin' do
+      initial_url = 'http://public.test/start'
+      blocked_url = 'http://user:secret@public.test/private'
+      stub_dns('public.test' => public_address)
+      stub_request(:head, initial_url).to_return(status: 301, headers: { 'Location' => blocked_url })
+
+      expect { described_class.fetch(initial_url) }.to raise_error(
+        URLCanonicalize::Exception::Security,
+        'URLs containing userinfo are not allowed'
+      )
+    end
+
+    it 'allows a private destination only when explicitly enabled' do
+      url = 'http://private.test'
+      stub_dns('private.test' => '127.0.0.1')
+      stub_request(:head, url).to_return(status: 200)
+      stub_request(:get, url).to_return(status: 200)
+
+      expect(described_class.fetch(url, allow_private_networks: true))
+        .to be_a(URLCanonicalize::Response::Success)
+    end
+
+    it 'keeps using the pinned address for later paths on the same origin' do
+      initial_url = 'http://public.test/start'
+      final_url = 'http://public.test/final'
+      resolutions = 0
+      allow(Addrinfo).to receive(:getaddrinfo) do |_host, port, *_arguments|
+        resolutions += 1
+        address = resolutions == 1 ? public_address : '127.0.0.1'
+        [Addrinfo.tcp(address, port)]
+      end
+      stub_request(:head, initial_url).to_return(status: 301, headers: { 'Location' => final_url })
+      stub_request(:head, final_url).to_return(status: 200)
+      stub_request(:get, final_url).to_return(status: 200)
+
+      expect(described_class.fetch(initial_url)).to be_a(URLCanonicalize::Response::Success)
+      expect(resolutions).to eq(1)
+    end
+
+    it 'surfaces TLS verification failures as fetch failures' do
+      url = 'https://public.test'
+      stub_dns('public.test' => public_address)
+      stub_request(:head, url).to_raise(OpenSSL::SSL::SSLError.new('certificate verify failed'))
+
+      expect { described_class.fetch(url) }.to raise_error(
+        URLCanonicalize::Exception::Failure,
+        /certificate verify failed/
+      )
+    end
   end
 
-  it 'returns successfully for a host name' do
-    expect(described_class.fetch(host)).to be_a(URLCanonicalize::Response::Success)
-  end
-
-  it 'canonicalizes a URL' do
-    expect(url.canonicalize).to eq(url)
+  def stub_dns(hosts)
+    allow(Addrinfo).to receive(:getaddrinfo) do |host, port, *_arguments|
+      [Addrinfo.tcp(hosts.fetch(host), port)]
+    end
   end
 end

--- a/url_canonicalize.gemspec
+++ b/url_canonicalize.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'url_canonicalize/version'
+require_relative 'lib/url_canonicalize/version'
 
 Gem::Specification.new do |s|
   s.name          = 'url_canonicalize'
@@ -18,12 +16,20 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.1.0'
 
-  s.files = `git ls-files`.split($RS).grep_v(%r{^spec/})
-
-  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  # A deterministic whitelist: runtime code plus user-facing documentation.
+  # Development configuration is deliberately not packaged.
+  s.files = Dir.glob('lib/**/*.rb', base: __dir__).sort + %w[CHANGELOG.md LICENSE README.md SECURITY.md]
   s.require_paths = ['lib']
+
+  s.metadata = {
+    'bug_tracker_uri' => "#{s.homepage}/issues",
+    'changelog_uri' => "#{s.homepage}/blob/main/CHANGELOG.md",
+    'documentation_uri' => 'https://www.rubydoc.info/gems/url_canonicalize',
+    'homepage_uri' => s.homepage,
+    'source_code_uri' => s.homepage,
+    'rubygems_mfa_required' => 'true'
+  }
 
   s.add_dependency 'addressable', '~> 2' # To normalize URLs
   s.add_dependency 'nokogiri', '>= 1.13' # To look for <link rel="canonical" ...> in HTML
-  s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## v1.0.1: secure-by-default fetching, a correct redirect state machine, and a refreshed test & release toolchain

This branch delivers the four issues milestoned for v1.0.1 (#184, #185, #189, #190),
plus mise for Ruby version management. Net effect: URL fetching is
secure by default, redirect/canonical-link handling is deterministic and
RFC-conformant, the suite enforces 100% line **and** branch coverage against a
fully stubbed network, and the gem is packaged deterministically and released
via RubyGems Trusted Publishing.

### Security hardening (#184 - `fix(security)`)

- TLS peer and hostname verification always on; no option to disable it.
- SSRF protection at every hop: initial URL, each redirect, and each canonical
  link is resolved and validated before connecting - loopback, private,
  link-local, CGN, multicast and other non-public ranges are rejected
  (fail-closed IPv6 allocation check), with `allow_private_networks: true` as
  an explicit escape hatch.
- DNS pinning (`Net::HTTP#ipaddr`), userinfo rejection, port allow-list,
  bounded response bodies (`max_body_bytes`) and one overall deadline
  (`total_timeout`) across all hops.
- New validated `Options` object; environment proxies deliberately disabled.

### Redirect & canonical-link state machine (#185 - `fix(http)`)

- All of 301/302/303/307/308 now follow their `Location` header (302/307 were
  previously treated as *successes*); a redirection without a usable Location
  is a failure.
- Redirects and followed canonical links share **one visited-URL set and one
  hop budget** (`max_redirects`), so canonical cycles - previously an infinite
  loop until the deadline - terminate deterministically, falling back to the
  last known good response when one exists.
- Proper `Link` header parsing (new `LinkHeader` module): multiple header
  fields, multiple links per field, quoted/unquoted and tokenized `rel`
  values, replacing a greedy regex that captured garbage across links.
- HTML canonicals matched case-insensitively by rel token and resolved against
  the document base URL (`<base href>` honoured); all references (including
  protocol-relative `//host/path`) resolved per RFC 3986; only http(s)
  targets followed.
- Per-hop state fully reset (a stale canonical URL and the HEAD→GET method
  choice previously leaked between hops).
- The hard-coded linkedin/crunchbase GET-only hack is replaced by a documented
  generic fallback: a HEAD rejected with 403/405/501 is retried once as GET.
- Failures preserve the underlying exception as the raised error's `cause`.

### Test & coverage strategy (#189 - `test`)

- `coveralls-ruby` removed (it pinned SimpleCov to 0.16.1 and caused
  misleading Renovate "SimpleCov" updates); SimpleCov 1.0 with **branch
  coverage enabled and 100% line + branch thresholds enforced on CI**.
- New HTTP-boundary specs (WebMock + stubbed DNS) covering redirect chains,
  canonical discovery, loop/budget termination, HEAD fallback, body limits and
  destination policy - no live network anywhere.
- Environment mutations isolated via a `with_env` helper; in-test randomness
  seeded from the RSpec seed; unseeded `.shuffle` removed. Verified across
  repeated randomized seeds.
- Branch coverage exposed a real bug: `casecmp` (integer, always truthy) made
  the `DEBUG=headers` guard a no-op, dumping response headers for any DEBUG
  value - fixed with `casecmp?`.

### Packaging, release automation & docs (#190 - `build`)

- Gemspec: deterministic whitelist (runtime code + user-facing docs) replaces
  the `git ls-files` shell-out; full RubyGems metadata (source, bug tracker,
  changelog, documentation, MFA retained).
- New `verify-gem` workflow (PRs + main): builds the gem, fails on any
  content deviation, installs it in a clean environment and requires it.
- New tag-triggered `release` workflow: reuses the verification, checks the
  tag matches `URLCanonicalize::VERSION`, and publishes via **RubyGems Trusted
  Publishing** (OIDC) from a protected `release` environment - no stored API
  key.
- CHANGELOG rewritten in Keep a Changelog format (0.2.0 → Unreleased
  reconstructed); README badges replaced (5 dead services removed) and docs
  added for supported Rubies, errors and extensions; new SECURITY.md and
  CONTRIBUTING.md.

### Behavior changes reviewers should be aware of

- Fetching private/internal hosts now raises `Exception::Security` unless
  `allow_private_networks: true` is passed.
- Temporary redirects (302/307) are now followed instead of being treated as
  the canonical endpoint.
- Bodies over 1 MiB (default) raise `Exception::ResponseTooLarge`; operations
  over 30 s raise `Exception::Timeout`.

### Verification

- 186 examples, 0 failures; 100.00% line and 100.00% branch coverage; stable
  across repeated randomized seeds; RuboCop clean apart from 4 pre-existing
  offenses also present on main.
- Built gem verified locally: exactly the 19 whitelisted files; clean-room
  install + require + smoke test of the live flow.

### Post-merge checklist

- [x] Push reconciliation tags: `v0.2.0` → `425bc8e`, `v0.2.1` → `5523a97`,
      `v1.0.0` → `74626e1` (safe: those commits predate the release workflow,
      so tagging them cannot trigger a publish), and create GitHub releases.
- [x] Create the protected `release` environment in repo settings.
- [x] Add the GitHub Actions trusted publisher on RubyGems.org
      (repo `dominicsayers/url_canonicalize`, workflow `release.yml`,
      environment `release`).
- [ ] Release v1.0.1 per CONTRIBUTING.md.

Fixes #184
Closes #185
Closes #189
Closes #190