### PR TITLE
build: Group development-only gems into one weekly Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Group development-only gems into one weekly PR; they are not user-visible so they get no changelog entry. Runtime gems, CI actions and vulnerability alerts still arrive as individual PRs.",
+      "matchManagers": ["bundler"],
+      "matchDepTypes": ["static_code_analysis", "test", "build"],
+      "groupName": "development dependencies",
+      "schedule": ["before 9am on monday"]
+    }
   ]
 }


### PR DESCRIPTION
Development dependencies are not user-visible, so their updates get no changelog entry and don't need individual review. Runtime gems, CI action updates and vulnerability alerts still arrive as separate pull requests, which is the signal to add an Unreleased entry.